### PR TITLE
feat: modernize UI with glassmorphism and brand palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,11 @@
     <!-- Tailwind CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
 
-    <!-- (facultatif) Police propre -->
+    <!-- Polices Google : Inter (texte) + Space Grotesk (titres) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
 
@@ -41,9 +41,19 @@
       tailwind.config = {
         theme: {
           extend: {
-            fontFamily: { sans: ['Inter', 'ui-sans-serif', 'system-ui'] },
-            // Exemple couleurs perso:
-            // colors: { brand: { 500: '#6B8AFB', 600: '#4F6CF0' } }
+            fontFamily: {
+              sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+              display: ['Space Grotesk', 'Inter', 'ui-sans-serif'],
+            },
+            colors: {
+              brand: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+              },
+            },
           },
         },
       };
@@ -54,7 +64,7 @@
   SECTION D — CORPS / RACINE APP
   ➜ Ne garde qu’un #root, ajoute tes wrappers ici si besoin
 ========================================= -->
-  <body class="min-h-screen bg-white text-slate-900">
+  <body class="min-h-screen bg-gradient-to-br from-brand-50 via-white to-cyan-50 text-slate-900 antialiased">
     <!-- Point d’ancrage React/Vite -->
     <div id="root"></div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,20 +36,20 @@ export default function NurseToolkitApp() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50 text-slate-900 font-sans">
+    <div className="min-h-screen text-slate-900 font-sans">
       <Header onChangeTab={setTab} active={tab} />
 
       <main className="mx-auto w-full max-w-3xl px-4 pb-28 sm:pb-24">
         <Greeting weather={weather} />
         <Tabs active={tab} onChange={setTab} />
-        <div className="mt-6 rounded-3xl bg-white shadow-lg p-6 border border-slate-100">
+        <div className="mt-6 rounded-3xl bg-white/60 backdrop-blur-xl shadow-xl p-6 border border-white/70">
           <TabContent active={tab} />
         </div>
       </main>
 
       <BottomNav active={tab} onChange={setTab} />
 
-      <footer className="mt-10 border-t bg-white/80 backdrop-blur-lg shadow-inner">
+      <footer className="mt-10 border-t border-white/40 bg-white/60 backdrop-blur">
         <div className="mx-auto w-full max-w-3xl px-4 py-6 text-sm text-slate-500">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
             <div>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -69,8 +69,8 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
       </div>
 
       {/* Titre sobre avec gradient léger */}
-      <h2 className="mt-2 text-3xl sm:text-4xl font-extrabold leading-tight">
-        <span className="bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 bg-clip-text text-transparent">
+      <h2 className="mt-2 text-3xl sm:text-4xl font-extrabold leading-tight font-display">
+        <span className="bg-gradient-to-r from-brand-700 via-brand-600 to-cyan-600 bg-clip-text text-transparent">
           {dynamicTitle}
         </span>
       </h2>
@@ -105,11 +105,11 @@ export function Tabs({
 
   const cls = (is: boolean) =>
     [
-      'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-900/20',
+      'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500/20',
       'flex items-center justify-center gap-2 px-3 py-2 text-sm',
       is
-        ? 'bg-slate-900 text-white border-slate-900'
-        : 'bg-white hover:bg-slate-50 text-slate-700',
+        ? 'bg-gradient-to-r from-brand-600 to-cyan-500 text-white border-transparent shadow'
+        : 'bg-white/60 hover:bg-white text-slate-700 border-white/60',
     ].join(' ');
 
   return (

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -12,12 +12,12 @@ export function Header({
   active: TabKey;
 }) {
   return (
-    <header className="sticky top-0 z-40 backdrop-blur bg-white/80 border-b border-slate-200/60">
+    <header className="sticky top-0 z-40 backdrop-blur-xl bg-white/60 border-b border-white/40">
       <div className="mx-auto w-full max-w-3xl px-4 py-3 flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight">
+        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight font-display">
           <span className="inline-flex items-center gap-2">
             <span
-              className="inline-block h-6 w-6 rounded-xl bg-slate-900"
+              className="inline-block h-6 w-6 rounded-xl bg-gradient-to-br from-brand-500 to-cyan-500"
               aria-hidden
             />
             <span>Outils de Chloé</span>
@@ -78,10 +78,10 @@ export function TopLink({
   return (
     <button
       onClick={() => onClick(id)}
-      className={`px-3 py-1.5 rounded-full border transition focus:outline-none focus:ring-2 focus:ring-slate-900/20 ${
+      className={`px-3 py-1.5 rounded-full border transition focus:outline-none focus:ring-2 focus:ring-brand-500/20 ${
         is
-          ? 'bg-slate-900 text-white border-slate-900'
-          : 'bg-white hover:bg-slate-50'
+          ? 'bg-gradient-to-r from-brand-600 to-cyan-500 text-white border-transparent shadow'
+          : 'bg-white/60 hover:bg-white text-slate-700 border-white/60'
       }`}
       aria-current={is ? 'page' : undefined}
     >
@@ -99,7 +99,6 @@ export function BottomNav({
 }) {
   const items: { id: TabKey; icon: string; label: string }[] = [
     { id: 'calculs', icon: '💊', label: 'Calculs' },
-    { id: 'scores', icon: '📈', label: 'Scores' },
     { id: 'gaz', icon: '🩸', label: 'Gaz' },
     { id: 'patient', icon: '🧪', label: 'Patient' },
     { id: 'notes', icon: '🗒️', label: 'Notes' },
@@ -110,16 +109,16 @@ export function BottomNav({
       className="fixed bottom-0 inset-x-0 z-40 sm:hidden"
       aria-label="Navigation mobile"
     >
-      <div className="mx-auto max-w-3xl bg-white/90 backdrop-blur border-t border-slate-200">
-        <div className="grid grid-cols-6">
+      <div className="mx-auto max-w-3xl bg-white/60 backdrop-blur-xl border-t border-white/40">
+        <div className="grid grid-cols-5">
           {items.map((t) => {
             const is = active === t.id;
             return (
               <button
                 key={t.id}
                 onClick={() => onChange(t.id)}
-                className={`flex flex-col items-center justify-center py-2 text-xs focus:outline-none focus:ring-2 focus:ring-slate-900/20 ${
-                  is ? 'text-slate-900' : 'text-slate-500'
+                className={`flex flex-col items-center justify-center py-2 text-xs focus:outline-none focus:ring-2 focus:ring-brand-500/20 ${
+                  is ? 'text-brand-600' : 'text-slate-500'
                 }`}
                 aria-current={is ? 'page' : undefined}
               >

--- a/src/tabs/Calculs.tsx
+++ b/src/tabs/Calculs.tsx
@@ -67,15 +67,21 @@ function DoseCalculator() {
   return (
     <Card title="Calcul de dose" subtitle="Règle de trois, mg/kg, dilution">
       <div className="flex gap-2 mb-2 overflow-x-auto no-scrollbar">
-        {[
-          { id: "mgkg", label: "mg/kg" },
-          { id: "regle3", label: "Règle de trois" },
-          { id: "dilution", label: "Dilution" },
-        ].map((m) => (
+        {(
+          [
+            { id: "mgkg", label: "mg/kg" },
+            { id: "regle3", label: "Règle de trois" },
+            { id: "dilution", label: "Dilution" },
+          ] as const
+        ).map((m) => (
           <button
             key={m.id}
-            onClick={() => setMode(m.id as any)}
-            className={`px-3 py-1.5 rounded-full text-sm border whitespace-nowrap ${mode === m.id ? "bg-slate-900 text-white border-slate-900" : "bg-white hover:bg-slate-50"}`}
+            onClick={() => setMode(m.id)}
+            className={`px-3 py-1.5 rounded-full text-sm border whitespace-nowrap ${
+              mode === m.id
+                ? "bg-slate-900 text-white border-slate-900"
+                : "bg-white hover:bg-slate-50"
+            }`}
           >
             {m.label}
           </button>

--- a/src/tabs/Gazometrie.tsx
+++ b/src/tabs/Gazometrie.tsx
@@ -10,7 +10,6 @@ import {
   aAGradientCustom,
   pfRatio,
   primaryDisorder,
-  toNumAllowEmpty,
 } from '../utils';
 
 export function GazometrieTab() {
@@ -112,7 +111,9 @@ function ABGTool() {
     ].filter(Boolean);
     try {
       await navigator.clipboard.writeText(lines.join('\n'));
-    } catch {}
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (
@@ -226,7 +227,7 @@ function ABGTool() {
           <Chip>AG {round(ag)}</Chip>
           <Chip>AGcorr {round(agCorr)}</Chip>
           {Number.isFinite(lactate) && (
-            <Chip tone={lactTone as any}>Lactate {round(lactate)} mmol/L</Chip>
+            <Chip tone={lactTone}>Lactate {round(lactate)} mmol/L</Chip>
           )}
         </div>
         <div className="flex gap-2">

--- a/src/tabs/PatientNotes.tsx
+++ b/src/tabs/PatientNotes.tsx
@@ -2,7 +2,7 @@
 // Rôle: onglets Patient / Notes / À propos
 
 import React, { useState } from 'react';
-import { Card, Field, Result, FieldStr } from '../ui/UI';
+import { Card, Field, Result } from '../ui/UI';
 import { round, safeDiv } from '../utils';
 
 export function PatientTab() {
@@ -60,7 +60,7 @@ function CrCl() {
         <select
           className="w-full rounded-xl border px-3 py-2 text-base"
           value={sexe}
-          onChange={(e) => setSexe(e.target.value as any)}
+          onChange={(e) => setSexe(e.target.value as 'F' | 'M')}
         >
           <option value="F">Femme</option>
           <option value="M">Homme</option>
@@ -68,7 +68,7 @@ function CrCl() {
         <select
           className="w-full rounded-xl border px-3 py-2 text-base"
           value={unit}
-          onChange={(e) => setUnit(e.target.value as any)}
+          onChange={(e) => setUnit(e.target.value as 'umol' | 'mgdl')}
         >
           <option value="umol">µmol/L</option>
           <option value="mgdl">mg/dL</option>
@@ -115,18 +115,62 @@ function BMI() {
 }
 
 function NoteBlock() {
-  const [txt, setTxt] = useState<string>('');
+  const [txt, setTxt] = useState('');
+  const [notes, setNotes] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('notes') || '[]');
+    } catch {
+      return [];
+    }
+  });
+
+  function saveNotes(n: string[]) {
+    setNotes(n);
+    try {
+      localStorage.setItem('notes', JSON.stringify(n));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function addNote() {
+    const v = txt.trim();
+    if (!v) return;
+    saveNotes([...notes, v]);
+    setTxt('');
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      addNote();
+    }
+  }
+
   return (
     <Card
       title="Bloc-notes rapide"
       subtitle="Sauvegardez localement vos repères (reste dans ce navigateur)"
     >
       <textarea
-        className="w-full min-h-[140px] rounded-xl border p-3 focus:outline-none focus:ring-2 focus:ring-slate-900/20"
+        className="w-full min-h-[80px] rounded-xl border p-3 focus:outline-none focus:ring-2 focus:ring-slate-900/20"
         placeholder="Ex: dilution habituelle, repères de service, check-lists..."
         value={txt}
         onChange={(e) => setTxt(e.target.value)}
+        onKeyDown={onKeyDown}
       />
+      {notes.length > 0 && (
+        <ul className="mt-4 space-y-2">
+          {notes.map((n, i) => (
+            <li
+              key={i}
+              className="rounded-xl border bg-white/70 px-3 py-2 text-sm"
+            >
+              {n}
+            </li>
+          ))}
+        </ul>
+      )}
       <div className="text-[11px] text-slate-500 mt-2">
         Astuce: <em>Ctrl/Cmd + P</em> pour imprimer la page / exporter en PDF.
       </div>

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -31,7 +31,7 @@ export type FieldProps = {
   label: string;
   suffix?: string;
   value: number | string;
-  onChange: (value: any) => void;
+  onChange: (value: number | string) => void;
   type?: 'number' | 'text';
   min?: number;
   max?: number;
@@ -60,11 +60,11 @@ export function Field({
           className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20"
           type={type}
           inputMode={type === 'number' ? 'decimal' : undefined}
-          value={value as any}
+          value={value}
           min={min}
           max={max}
           placeholder={placeholder}
-          step={step as any}
+          step={step}
           onChange={(e) => onChange(toNumAllowEmpty(e.target.value))}
         />
         {suffix && <div className="text-sm text-slate-500">{suffix}</div>}
@@ -125,7 +125,7 @@ export function Select({
 }: {
   label: string;
   value: string | number;
-  onChange: (value: any) => void;
+  onChange: (value: string | number) => void;
   options: SelectOption[];
 }) {
   return (
@@ -133,7 +133,7 @@ export function Select({
       <div className="text-sm text-slate-700 mb-1">{label}</div>
       <select
         className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20 bg-white"
-        value={value as any}
+        value={value}
         onChange={(e) =>
           onChange(
             typeof value === 'number' ? Number(e.target.value) : e.target.value


### PR DESCRIPTION
## Summary
- add Space Grotesk and branded color palette via Tailwind CDN
- redesign navigation, tabs, and cards with glassmorphism and gradients
- fix mobile menu bubbles and enable persistent notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68960c70439883328ac6f581c0b1504b