### PR TITLE
Add temperature conversion utilities

### DIFF
--- a/src/tests/Tests.tsx
+++ b/src/tests/Tests.tsx
@@ -8,6 +8,8 @@ import {
   aAGradientCustom,
   correctedAnionGap,
   round,
+  celsiusToFahrenheit,
+  fahrenheitToCelsius,
 } from '../utils';
 
 export function Tests() {
@@ -60,6 +62,18 @@ export function Tests() {
       expected: 21,
       actual: correctedAnionGap(16, 2.0),
       pass: approxEqual(correctedAnionGap(16, 2.0), 21, 0.01),
+    },
+    {
+      name: 'Celsius vers Fahrenheit 25°C',
+      expected: 77,
+      actual: celsiusToFahrenheit(25),
+      pass: approxEqual(celsiusToFahrenheit(25), 77, 0.01),
+    },
+    {
+      name: 'Fahrenheit vers Celsius 77°F',
+      expected: 25,
+      actual: fahrenheitToCelsius(77),
+      pass: approxEqual(fahrenheitToCelsius(77), 25, 0.01),
     },
   ];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,18 @@ export function toNumAllowEmpty(v: string) {
   return Number.isFinite(n) ? n : Number.NaN;
 }
 
+export function celsiusToFahrenheit(c: number) {
+  const x = Number(c)
+  if (!Number.isFinite(x)) return 0
+  return (x * 9) / 5 + 32
+}
+
+export function fahrenheitToCelsius(f: number) {
+  const x = Number(f)
+  if (!Number.isFinite(x)) return 0
+  return ((x - 32) * 5) / 9
+}
+
 // === Gazométrie helpers ===
 export function pfRatio(PaO2: number, FiO2: number) {
   if (FiO2 <= 0) return 0;


### PR DESCRIPTION
## Summary
- add Celsius/Fahrenheit conversion helpers
- extend integration tests with temperature conversions

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0d7adea08332b320c1874b760f3f