### PR TITLE
feat: add accessible AppShell layout

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'theme';
+
+type Theme = 'light' | 'dark';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem(STORAGE_KEY) as Theme) || 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <button
+      type="button"
+      aria-pressed={theme === 'dark'}
+      onClick={toggle}
+      className="focus-ring focus:outline-none touch-target rounded-md p-2 hover:bg-muted active:bg-muted/80"
+    >
+      Night-Shift
+    </button>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,47 @@
+// File: src/components/layout/AppShell.tsx
+// Rôle: cadre général avec topbar fixe et lien de contournement
+
+import type { ReactNode } from 'react';
+import ThemeToggle from '../ThemeToggle';
+
+interface AppShellProps {
+  title: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export default function AppShell({ title, actions, children }: AppShellProps) {
+  return (
+    <>
+      <a
+        href="#main-content"
+        className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:top-2 focus-visible:left-2 focus-visible:z-50 focus-visible:rounded-md focus-visible:bg-card focus-visible:px-4 focus-visible:py-2 focus:outline-none focus-ring touch-target"
+      >
+        Aller au contenu
+      </a>
+
+      <header
+        role="banner"
+        className="fixed inset-x-0 top-0 z-40 h-16 border-b border-muted bg-card/90 backdrop-blur flex items-center text-fg"
+      >
+        <div className="mx-auto flex w-full max-w-[1200px] items-center justify-between px-4 md:px-6">
+          <h1 className="text-lg font-semibold">{title}</h1>
+          <div className="flex items-center gap-2" role="toolbar">
+            {actions}
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main
+        id="main-content"
+        role="main"
+        tabIndex={-1}
+        className="pt-16 mx-auto w-full max-w-[1200px] px-4 md:px-6"
+      >
+        {children}
+      </main>
+    </>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import './styles/tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -28,11 +30,3 @@ textarea {
   font-family: inherit;
 }
 
-/* Amélioration de l'accessibilité */
-button:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: 2px solid #3b82f6;
-  outline-offset: 2px;
-}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,36 @@
+:root {
+  color-scheme: light;
+  --bg: #ffffff;
+  --fg: #1f2937;
+  --card: #f9fafb;
+  --muted: #e5e7eb;
+  --primary: #2563eb;
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --fg: #f1f5f9;
+  --card: #1e293b;
+  --muted: #334155;
+  --primary: #3b82f6;
+}
+
+html, body {
+  background-color: var(--bg);
+  color: var(--fg);
+}
+
+@layer utilities {
+  .focus-ring:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .touch-target {
+    @apply inline-flex items-center justify-center;
+  }
+  html[data-theme='dark'] .touch-target {
+    min-width: 59px;
+    min-height: 59px;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,15 @@
 export default {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        bg: 'var(--bg)',
+        fg: 'var(--fg)',
+        card: 'var(--card)',
+        muted: 'var(--muted)',
+        primary: 'var(--primary)',
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add `AppShell` layout with fixed top bar, skip link, and dark mode toggle
- define light/dark design tokens with focus-ring utility
- map CSS variables in Tailwind and persist user's Night-Shift preference

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de203feb083328e3cc1be2a9cd1c0