### PR TITLE
feat: introduce verdant care theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,15 +45,6 @@
               sans: ['Inter', 'ui-sans-serif', 'system-ui'],
               display: ['Space Grotesk', 'Inter', 'ui-sans-serif'],
             },
-            colors: {
-              brand: {
-                50: '#eef2ff',
-                100: '#e0e7ff',
-                500: '#6366f1',
-                600: '#4f46e5',
-                700: '#4338ca',
-              },
-            },
           },
         },
       };
@@ -64,7 +55,7 @@
   SECTION D — CORPS / RACINE APP
   ➜ Ne garde qu’un #root, ajoute tes wrappers ici si besoin
 ========================================= -->
-  <body class="min-h-screen bg-gradient-to-br from-brand-50 via-white to-cyan-50 text-slate-900 antialiased">
+  <body class="min-h-screen bg-bg text-foreground antialiased">
     <!-- Point d’ancrage React/Vite -->
     <div id="root"></div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,18 +10,25 @@ import { fadeInUp } from './ui/motion/presets';
 import { transition } from './ui/motion/transition';
 import { useReducedMotion } from './ui/motion/ReducedMotion';
 import { WeatherWidget, type Weather } from './WeatherWidget';
+import { Toggle } from './ui/UI';
+import { Sprout } from './Sprout';
 
 export type TabKey = 'calculs' | 'gaz' | 'patient' | 'notes' | 'apropos';
 
 export default function NurseToolkitApp() {
   const [tab, setTab] = useState<TabKey>('gaz');
   const [weather, setWeather] = useState<Weather | null>(null);
+  const [showSprout, setShowSprout] = useState(true);
 
   const prefersReduced = useReducedMotion();
 
   return (
-    <div className="min-h-screen text-slate-900 font-sans">
-      <Header onChangeTab={setTab} active={tab} />
+    <div className="min-h-screen bg-bg text-foreground font-sans">
+      <Header
+        onChangeTab={setTab}
+        active={tab}
+        sprout={showSprout ? <Sprout mood={weather?.condition} /> : undefined}
+      />
 
       <motion.main
         className="mx-auto w-full max-w-3xl px-4 pb-28 sm:pb-24"
@@ -32,11 +39,16 @@ export default function NurseToolkitApp() {
       >
         <Greeting weather={weather} />
         <WeatherWidget onWeather={setWeather} />
+        <Toggle
+          label="Mascotte Sprout"
+          checked={showSprout}
+          onChange={setShowSprout}
+        />
         <Tabs active={tab} onChange={setTab} />
         <AnimatePresence mode="wait">
           <motion.div
             key={tab}
-            className="mt-6 rounded-3xl bg-white/60 backdrop-blur-xl shadow-xl p-6 border border-white/70"
+            className="mt-6 rounded-xl md:rounded-2xl bg-surface/80 backdrop-blur-xl shadow-elevation-3 p-6 border border-border/50"
             initial="hidden"
             animate="visible"
             exit="hidden"
@@ -50,8 +62,8 @@ export default function NurseToolkitApp() {
 
       <BottomNav active={tab} onChange={setTab} />
 
-      <footer className="mt-10 border-t border-white/40 bg-white/60 backdrop-blur">
-        <div className="mx-auto w-full max-w-3xl px-4 py-6 text-sm text-slate-500">
+      <footer className="mt-10 border-t border-border/50 bg-surface/80 backdrop-blur">
+        <div className="mx-auto w-full max-w-3xl px-4 py-6 text-sm text-muted-foreground">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
             <div>
               ⚠️ Cet outil aide uniquement aux calculs infirmiers — il ne

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -97,7 +97,7 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
   return (
     <section className="pt-6 sm:pt-8 mb-2">
       {/* Ligne de contexte (ton + date + emoji météo discret) */}
-      <div className="flex flex-wrap items-center gap-2 text-[13px] uppercase tracking-wider text-slate-500">
+      <div className="flex flex-wrap items-center gap-2 text-[13px] uppercase tracking-wider text-muted-foreground">
         <span className="inline-flex items-center gap-1">
           <span aria-hidden>{wxIcon}</span>
           <span>{baseTone}</span>
@@ -108,13 +108,13 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
 
       {/* Titre sobre avec gradient léger */}
       <h2 className="mt-2 text-3xl sm:text-4xl font-extrabold leading-tight font-display">
-        <span className="bg-gradient-to-r from-brand-700 via-brand-600 to-cyan-600 bg-clip-text text-transparent">
+        <span className="bg-gradient-to-r from-primary to-info bg-clip-text text-transparent">
           {dynamicTitle}
         </span>
       </h2>
 
       {/* Sous-texte concis */}
-      <p className="mt-2 text-slate-600">
+      <p className="mt-2 text-muted-foreground">
         Calculs rapides, repères utiles et outils patients.
         <span className="hidden sm:inline">
           {' '}
@@ -143,11 +143,11 @@ export function Tabs({
 
   const cls = (is: boolean) =>
     [
-      'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500/20',
+      'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-ring',
       'flex items-center justify-center gap-2 px-3 py-2 text-sm',
       is
-        ? 'bg-gradient-to-r from-brand-600 to-cyan-500 text-white border-transparent shadow'
-        : 'bg-white/60 hover:bg-white text-slate-700 border-white/60',
+        ? 'bg-gradient-to-r from-primary to-info text-primary-fg border-transparent shadow'
+        : 'bg-bg/60 hover:bg-bg text-foreground border-border/50',
     ].join(' ');
 
   return (

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,62 +1,68 @@
 // File: src/Navigation.tsx
 // Rôle: en-têtes et navigation (desktop + mobile)
 
+import React from 'react';
 import type { TabKey } from './App';
 
 export function Header({
   onChangeTab,
   active,
+  sprout,
 }: {
   onChangeTab: (t: TabKey) => void;
   active: TabKey;
+  sprout?: React.ReactNode;
 }) {
   return (
-    <header className="sticky top-0 z-40 backdrop-blur-xl bg-white/60 border-b border-white/40">
+    <header className="sticky top-0 z-40 backdrop-blur-xl bg-bg/60 border-b border-border/50">
       <div className="mx-auto w-full max-w-3xl px-4 py-3 flex items-center justify-between">
         <h1 className="text-xl sm:text-2xl font-semibold tracking-tight font-display">
           <span className="inline-flex items-center gap-2">
             <span
-              className="inline-block h-6 w-6 rounded-xl bg-gradient-to-br from-brand-500 to-cyan-500"
+              className="inline-block h-6 w-6 rounded-xl bg-primary"
               aria-hidden
             />
             <span>Outils de Chloé</span>
           </span>
         </h1>
-        <nav
-          className="hidden sm:flex gap-2 text-sm"
-          aria-label="Navigation principale"
-        >
-          <TopLink
-            id="calculs"
-            label="Calculs"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="gaz"
-            label="Gazométrie"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="patient"
-            label="Patient"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="notes"
-            label="Notes"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="apropos"
-            label="À propos"
-            active={active}
-            onClick={onChangeTab}
-          />
-        </nav>
+        <div className="flex items-center gap-4">
+          <nav
+            className="hidden sm:flex gap-2 text-sm"
+            aria-label="Navigation principale"
+          >
+            <TopLink
+              id="calculs"
+              label="Calculs"
+              active={active}
+              onClick={onChangeTab}
+            />
+            <TopLink
+              id="gaz"
+              label="Gazométrie"
+              active={active}
+              onClick={onChangeTab}
+            />
+            <TopLink
+              id="patient"
+              label="Patient"
+              active={active}
+              onClick={onChangeTab}
+            />
+            <TopLink
+              id="notes"
+              label="Notes"
+              active={active}
+              onClick={onChangeTab}
+            />
+            <TopLink
+              id="apropos"
+              label="À propos"
+              active={active}
+              onClick={onChangeTab}
+            />
+          </nav>
+          {sprout && <div className="hidden sm:block" aria-hidden>{sprout}</div>}
+        </div>
       </div>
     </header>
   );
@@ -77,10 +83,10 @@ export function TopLink({
   return (
     <button
       onClick={() => onClick(id)}
-      className={`px-3 py-1.5 rounded-full border transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-brand-500/20 hover:scale-105 active:scale-95 ${
+      className={`px-3 py-1.5 rounded-full border transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-ring hover:scale-105 active:scale-95 ${
         is
-          ? 'bg-gradient-to-r from-brand-600 to-cyan-500 text-white border-transparent shadow'
-          : 'bg-white/60 hover:bg-white text-slate-700 border-white/60'
+          ? 'bg-primary text-primary-fg border-transparent shadow'
+          : 'bg-bg/60 hover:bg-bg text-foreground border-border/50'
       }`}
       aria-current={is ? 'page' : undefined}
     >
@@ -108,7 +114,7 @@ export function BottomNav({
       className="fixed bottom-0 inset-x-0 z-40 sm:hidden"
       aria-label="Navigation mobile"
     >
-      <div className="mx-auto max-w-3xl bg-white/60 backdrop-blur-xl border-t border-white/40">
+      <div className="mx-auto max-w-3xl bg-bg/60 backdrop-blur-xl border-t border-border/50">
         <div className="grid grid-cols-5">
           {items.map((t) => {
             const is = active === t.id;
@@ -116,8 +122,8 @@ export function BottomNav({
               <button
                 key={t.id}
                 onClick={() => onChange(t.id)}
-                className={`flex flex-col items-center justify-center py-2 text-xs transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-brand-500/20 hover:scale-105 active:scale-95 ${
-                  is ? 'text-brand-600' : 'text-slate-500'
+                className={`flex flex-col items-center justify-center py-2 text-xs transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-ring hover:scale-105 active:scale-95 ${
+                  is ? 'text-primary' : 'text-muted-foreground'
                 }`}
                 aria-current={is ? 'page' : undefined}
               >

--- a/src/Sprout.tsx
+++ b/src/Sprout.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+// Sprout : petite mascotte cactus, optionnelle
+export function Sprout({ mood }: { mood?: string | null }) {
+  const cond = (mood || '').toLowerCase();
+  const sun = cond.includes('soleil');
+  const rain = cond.includes('pluie');
+  return (
+    <div className="relative h-6 w-6 text-primary" aria-hidden>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-6 w-6"
+      >
+        <path d="M12 22V12" />
+        <path d="M7 10v2a5 5 0 0 0 10 0v-2" />
+        <path d="M5 13V8a2 2 0 1 1 4 0v5" />
+        <path d="M15 11V6a2 2 0 1 1 4 0v5" />
+      </svg>
+      {sun && (
+        <svg
+          className="absolute -top-1 -right-1 h-3 w-3"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 1v2" />
+          <path d="M12 21v2" />
+          <path d="M4.22 4.22l1.42 1.42" />
+          <path d="M18.36 18.36l1.42 1.42" />
+          <path d="M1 12h2" />
+          <path d="M21 12h2" />
+          <path d="M4.22 19.78l1.42-1.42" />
+          <path d="M18.36 5.64l1.42-1.42" />
+        </svg>
+      )}
+      {rain && (
+        <svg
+          className="absolute -top-1 -right-1 h-3 w-3"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 2a4 4 0 0 0-4 4c0 3 4 7 4 7s4-4 4-7a4 4 0 0 0-4-4z" />
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/src/WeatherWidget.tsx
+++ b/src/WeatherWidget.tsx
@@ -104,7 +104,9 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather }: Props) {
   if (loading) {
     return (
       <div
-        className={`mt-2 h-8 w-32 rounded bg-white/50 ${prefersReduced ? '' : 'animate-pulse'}`}
+        className={`mt-4 h-24 w-full rounded-xl bg-card/50 ${
+          prefersReduced ? '' : 'animate-pulse'
+        }`}
         aria-hidden
       />
     );
@@ -112,18 +114,38 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather }: Props) {
 
   if (error || !data) {
     return (
-      <div className="mt-2 text-sm text-slate-500" role="status">
+      <div
+        className="mt-4 h-24 rounded-xl border border-border bg-card flex items-center justify-center text-sm text-muted-foreground"
+        role="status"
+      >
         {error || 'Météo indisponible'}
       </div>
     );
   }
 
+  const msg =
+    data.temp >= 25
+      ? 'Reste hydraté·e'
+      : data.temp <= 0
+      ? 'Couvre-toi !'
+      : 'Belle journée';
+
   return (
-    <div className="mt-2 flex items-center gap-2 text-slate-700">
-      <span aria-hidden>{iconFor(data.condition)}</span>
-      <span className="text-sm">
-        {Math.round(data.temp)}°C — {data.condition}
-      </span>
+    <div className="mt-4 flex h-24 items-center justify-between rounded-xl border border-border bg-card p-4 shadow-elevation-1">
+      <div className="flex items-center gap-3 text-foreground">
+        <span className="h-10 w-10" aria-hidden>
+          {iconFor(data.condition)}
+        </span>
+        <div>
+          <div className="text-3xl font-bold leading-none">
+            {Math.round(data.temp)}°C
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {data.condition}
+          </div>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground italic">{msg}</p>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,37 +2,99 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Reset minimal pour Tailwind */
-* {
-  box-sizing: border-box;
-}
+@layer base {
+  :root {
+    /* Couleurs sémantiques claires */
+    --bg: 0 0% 100%;
+    --foreground: 220 13% 18%;
+    --surface: 0 0% 98%;
+    --card: 0 0% 100%;
+    --card-foreground: 220 13% 18%;
+    --primary: 153 47% 40%;
+    --primary-fg: 0 0% 100%;
+    --muted: 140 20% 96%;
+    --muted-foreground: 150 3% 45%;
+    --border: 150 4% 80%;
+    --ring: 153 47% 40%;
+    --success: 151 55% 35%;
+    --success-fg: 0 0% 100%;
+    --warn: 40 100% 45%;
+    --warn-fg: 0 0% 100%;
+    --danger: 356 72% 45%;
+    --danger-fg: 0 0% 100%;
+    --info: 199 89% 48%;
+    --info-fg: 0 0% 100%;
+  }
 
-html,
-body {
-  margin: 0;
-  padding: 0;
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+  .dark {
+    /* Palette sombre douce pour les nuits de garde */
+    --bg: 146 30% 8%;
+    --foreground: 0 0% 95%;
+    --surface: 146 22% 12%;
+    --card: 146 22% 14%;
+    --card-foreground: 0 0% 95%;
+    --primary: 153 47% 40%;
+    --primary-fg: 0 0% 100%;
+    --muted: 146 15% 18%;
+    --muted-foreground: 150 5% 65%;
+    --border: 146 20% 18%;
+    --ring: 153 47% 40%;
+    --success: 151 55% 40%;
+    --success-fg: 0 0% 10%;
+    --warn: 40 95% 50%;
+    --warn-fg: 0 0% 10%;
+    --danger: 356 75% 60%;
+    --danger-fg: 0 0% 10%;
+    --info: 199 89% 60%;
+    --info-fg: 0 0% 10%;
+  }
 
-#root {
-  min-height: 100vh;
-}
+  /* Reset minimal pour Tailwind */
+  * {
+    box-sizing: border-box;
+  }
 
-/* Styles pour les éléments de formulaire */
-input,
-select,
-textarea {
-  font-family: inherit;
-}
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-color: hsl(var(--bg));
+    color: hsl(var(--foreground));
+    background-image: radial-gradient(
+      hsl(var(--foreground) / 0.03) 1px,
+      transparent 1px
+    );
+    background-size: 24px 24px;
+  }
 
-/* Amélioration de l'accessibilité */
-button:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: 2px solid #3b82f6;
-  outline-offset: 2px;
+  #root {
+    min-height: 100vh;
+  }
+
+  /* Styles pour les éléments de formulaire */
+  input,
+  select,
+  textarea {
+    font-family: inherit;
+  }
+
+  /* Amélioration de l'accessibilité */
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
+  @media (forced-colors: active) {
+    html,
+    body {
+      background-image: none;
+    }
+  }
 }

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -15,12 +15,12 @@ export function Card({
 }) {
   return (
     <section
-      className="rounded-3xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow"
+      className="rounded-xl md:rounded-2xl border border-border bg-card text-card-foreground p-5 shadow-elevation-1 hover:shadow-elevation-2 transition-shadow"
       aria-label={title}
     >
       <div className="mb-4">
         <h3 className="text-lg font-semibold tracking-tight">{title}</h3>
-        {subtitle && <p className="text-sm text-slate-600 mt-1">{subtitle}</p>}
+        {subtitle && <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>}
       </div>
       {children}
     </section>
@@ -53,11 +53,11 @@ export function Field({
   const id = React.useId();
   return (
     <label className="block mb-3" htmlFor={id}>
-      <div className="text-sm text-slate-700 mb-1">{label}</div>
+      <div className="text-sm text-muted-foreground mb-1">{label}</div>
       <div className="flex items-center gap-2">
         <input
           id={id}
-          className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20"
+          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type={type}
           inputMode={type === 'number' ? 'decimal' : undefined}
           value={value}
@@ -73,7 +73,7 @@ export function Field({
             )
           }
         />
-        {suffix && <div className="text-sm text-slate-500">{suffix}</div>}
+        {suffix && <div className="text-sm text-muted-foreground">{suffix}</div>}
       </div>
     </label>
   );
@@ -95,23 +95,23 @@ export function FieldStr({
   const id = React.useId();
   return (
     <label className="block mb-3" htmlFor={id}>
-      <div className="text-sm text-slate-700 mb-1">{label}</div>
+      <div className="text-sm text-muted-foreground mb-1">{label}</div>
       <div className="flex items-center gap-2">
         <input
           id={id}
-          className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20"
+          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type="text"
           inputMode="decimal"
           value={value}
           placeholder={placeholder}
           onChange={(e) => onChange(e.target.value)}
         />
-        {suffix && <div className="text-sm text-slate-500">{suffix}</div>}
+        {suffix && <div className="text-sm text-muted-foreground">{suffix}</div>}
         {value !== '' && (
           <button
             type="button"
             aria-label="Effacer"
-            className="text-slate-500 text-sm px-2 py-1 rounded-lg border hover:bg-slate-50"
+            className="text-muted-foreground text-sm px-2 py-1 rounded-md border border-border hover:bg-muted"
             onClick={() => onChange('')}
           >
             ×
@@ -136,9 +136,9 @@ export function Select({
 }) {
   return (
     <label className="block mb-3">
-      <div className="text-sm text-slate-700 mb-1">{label}</div>
+      <div className="text-sm text-muted-foreground mb-1">{label}</div>
       <select
-        className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20 bg-white"
+        className="w-full rounded-md border border-border bg-bg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
         value={String(value)}
         onChange={(e) =>
           onChange(
@@ -169,7 +169,7 @@ export function Toggle({ label, checked, onChange }: ToggleProps) {
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
       />
-      <span className="text-sm text-slate-700">{label}</span>
+      <span className="text-sm text-foreground">{label}</span>
     </label>
   );
 }
@@ -181,16 +181,87 @@ export function Chip({
   children: React.ReactNode;
   tone?: 'ok' | 'warn' | 'danger' | 'info';
 }) {
-  const map: Record<'ok' | 'warn' | 'danger' | 'info', string> = {
-    ok: 'bg-emerald-50 text-emerald-700 border-emerald-200',
-    warn: 'bg-amber-50 text-amber-700 border-amber-200',
-    danger: 'bg-rose-50 text-rose-700 border-rose-200',
-    info: 'bg-slate-50 text-slate-700 border-slate-200',
+  const toneMap: Record<
+    'ok' | 'warn' | 'danger' | 'info',
+    { cls: string; icon: React.ReactNode }
+  > = {
+    ok: {
+      cls: 'bg-success/20 text-success border-success/40',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-3 w-3"
+        >
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      ),
+    },
+    warn: {
+      cls: 'bg-warn/20 text-warn border-warn/40',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-3 w-3"
+        >
+          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          <path d="M12 9v4" />
+          <path d="M12 17h.01" />
+        </svg>
+      ),
+    },
+    danger: {
+      cls: 'bg-danger/20 text-danger border-danger/40',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-3 w-3"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M15 9l-6 6" />
+          <path d="M9 9l6 6" />
+        </svg>
+      ),
+    },
+    info: {
+      cls: 'bg-info/20 text-info border-info/40',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-3 w-3"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 16v-4" />
+          <path d="M12 8h.01" />
+        </svg>
+      ),
+    },
   };
+  const t = toneMap[tone];
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 ${map[tone]}`}
+      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium ${t.cls}`}
     >
+      <span aria-hidden>{t.icon}</span>
       {children}
     </span>
   );
@@ -198,7 +269,7 @@ export function Chip({
 
 export function Badge({ label }: { label: string }) {
   return (
-    <div className="text-xs rounded-full border px-2 py-1 bg-slate-50 text-slate-700">
+    <div className="text-xs rounded-full border border-border bg-muted text-muted-foreground px-2 py-1">
       {label}
     </div>
   );
@@ -212,14 +283,14 @@ export function Result({
   tone?: 'ok' | 'warn' | 'danger' | 'info';
 }) {
   const toneMap: Record<'ok' | 'warn' | 'danger' | 'info', string> = {
-    ok: 'bg-emerald-50 text-emerald-700 border-emerald-200',
-    warn: 'bg-amber-50 text-amber-700 border-amber-200',
-    danger: 'bg-rose-50 text-rose-700 border-rose-200',
-    info: 'bg-slate-50 text-slate-700 border-slate-200',
+    ok: 'bg-success/20 text-success border-success/40',
+    warn: 'bg-warn/20 text-warn border-warn/40',
+    danger: 'bg-danger/20 text-danger border-danger/40',
+    info: 'bg-info/20 text-info border-info/40',
   };
   const styles = toneMap[tone] || toneMap.ok;
   return (
-    <div className={`rounded-2xl border px-4 py-3 text-sm ${styles}`}>
+    <div className={`rounded-xl border px-4 py-3 text-sm ${styles}`}>
       {children}
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,56 @@
 export default {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        bg: "hsl(var(--bg))",
+        foreground: "hsl(var(--foreground))",
+        surface: "hsl(var(--surface))",
+        card: "hsl(var(--card))",
+        "card-foreground": "hsl(var(--card-foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          fg: "hsl(var(--primary-fg))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          fg: "hsl(var(--muted-foreground))",
+        },
+        border: "hsl(var(--border))",
+        ring: "hsl(var(--ring))",
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          fg: "hsl(var(--success-fg))",
+        },
+        warn: {
+          DEFAULT: "hsl(var(--warn))",
+          fg: "hsl(var(--warn-fg))",
+        },
+        danger: {
+          DEFAULT: "hsl(var(--danger))",
+          fg: "hsl(var(--danger-fg))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          fg: "hsl(var(--info-fg))",
+        },
+      },
+      borderRadius: {
+        sm: "0.25rem",
+        md: "0.5rem",
+        xl: "1rem",
+        "2xl": "1.5rem",
+      },
+      boxShadow: {
+        "elevation-1": "0 1px 2px 0 hsl(var(--foreground)/0.05)",
+        "elevation-2":
+          "0 2px 4px -1px hsl(var(--foreground)/0.05), 0 4px 6px -1px hsl(var(--foreground)/0.05)",
+        "elevation-3":
+          "0 10px 15px -3px hsl(var(--foreground)/0.1), 0 4px 6px -4px hsl(var(--foreground)/0.1)",
+        "elevation-4":
+          "0 20px 25px -5px hsl(var(--foreground)/0.1), 0 10px 10px -5px hsl(var(--foreground)/0.04)",
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add Verdant Care design tokens and Tailwind theme
- refresh app shell, cards, badges and weather widget with nature-inspired styles
- introduce optional Sprout mascot with toggle

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689deefca8588332b1ae5e2e42f895f0