### PR TITLE
feat: introduce Verdant Care theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   SECTION D — CORPS / RACINE APP
   ➜ Ne garde qu’un #root, ajoute tes wrappers ici si besoin
 ========================================= -->
-  <body class="min-h-screen bg-gradient-to-br from-brand-50 via-white to-cyan-50 text-slate-900 antialiased">
+  <body class="min-h-screen bg-background text-slate-900 antialiased">
     <!-- Point d’ancrage React/Vite -->
     <div id="root"></div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "framer-motion": "^11.0.0",
         "react": "^19.1.1",
+        "react-animated-weather": "^4.0.1",
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
@@ -2783,8 +2784,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2899,6 +2899,19 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3053,7 +3066,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3395,6 +3407,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3432,6 +3456,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-animated-weather": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-animated-weather/-/react-animated-weather-4.0.1.tgz",
+      "integrity": "sha512-ipEa3yW3rld1UAHAmm7Bltn5BOH3O2B491R0ws51kwFtqQ6fc5KWUiBQ0e4sO/XjoeqCkAN/Y98lWx1qZMR84g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prop-types": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -3442,6 +3477,13 @@
       "peerDependencies": {
         "react": "^19.1.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5982,8 +6024,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -6069,6 +6110,15 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -6181,8 +6231,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",
@@ -6377,6 +6426,17 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6394,6 +6454,12 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="
     },
+    "react-animated-weather": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-animated-weather/-/react-animated-weather-4.0.1.tgz",
+      "integrity": "sha512-ipEa3yW3rld1UAHAmm7Bltn5BOH3O2B491R0ws51kwFtqQ6fc5KWUiBQ0e4sO/XjoeqCkAN/Y98lWx1qZMR84g==",
+      "requires": {}
+    },
     "react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -6401,6 +6467,12 @@
       "requires": {
         "scheduler": "^0.26.0"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "framer-motion": "^11.0.0",
     "react": "^19.1.1",
+    "react-animated-weather": "^4.0.1",
     "react-dom": "^19.1.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,51 +16,61 @@ export type TabKey = 'calculs' | 'gaz' | 'patient' | 'notes' | 'apropos';
 export default function NurseToolkitApp() {
   const [tab, setTab] = useState<TabKey>('gaz');
   const [weather, setWeather] = useState<Weather | null>(null);
+  const [dark, setDark] = useState(false);
 
   const prefersReduced = useReducedMotion();
 
   return (
-    <div className="min-h-screen text-slate-900 font-sans">
-      <Header onChangeTab={setTab} active={tab} />
+    <div className={dark ? 'dark' : ''}>
+      <div className="min-h-screen bg-background text-slate-900 dark:text-slate-100 font-sans">
+        <Header
+          onChangeTab={setTab}
+          active={tab}
+          dark={dark}
+          onToggleDark={() => setDark((d) => !d)}
+        />
 
-      <motion.main
-        className="mx-auto w-full max-w-3xl px-4 pb-28 sm:pb-24"
-        initial="hidden"
-        animate="visible"
-        variants={prefersReduced ? undefined : fadeInUp}
-        transition={transition}
-      >
-        <Greeting weather={weather} />
-        <WeatherWidget onWeather={setWeather} />
-        <Tabs active={tab} onChange={setTab} />
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={tab}
-            className="mt-6 rounded-3xl bg-white/60 backdrop-blur-xl shadow-xl p-6 border border-white/70"
-            initial="hidden"
-            animate="visible"
-            exit="hidden"
-            variants={prefersReduced ? undefined : fadeInUp}
-            transition={transition}
-          >
-            <TabContent active={tab} />
-          </motion.div>
-        </AnimatePresence>
-      </motion.main>
+        <motion.main
+          className="mx-auto w-full max-w-3xl px-4 pb-28 sm:pb-24"
+          initial="hidden"
+          animate="visible"
+          variants={prefersReduced ? undefined : fadeInUp}
+          transition={transition}
+        >
+          <Greeting weather={weather} />
+          <WeatherWidget onWeather={setWeather} showSprout />
+          <Tabs active={tab} onChange={setTab} />
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={tab}
+              className="mt-6"
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
+              variants={prefersReduced ? undefined : fadeInUp}
+              transition={transition}
+            >
+              <div className="rounded-2xl bg-card shadow-e3 p-6 border border-border">
+                <TabContent active={tab} />
+              </div>
+            </motion.div>
+          </AnimatePresence>
+        </motion.main>
 
-      <BottomNav active={tab} onChange={setTab} />
+        <BottomNav active={tab} onChange={setTab} />
 
-      <footer className="mt-10 border-t border-white/40 bg-white/60 backdrop-blur">
-        <div className="mx-auto w-full max-w-3xl px-4 py-6 text-sm text-slate-500">
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-            <div>
-              ⚠️ Cet outil aide uniquement aux calculs infirmiers — il ne
-              remplace pas l'avis médical.
+        <footer className="mt-10 border-t border-border bg-surface/70 backdrop-blur-md">
+          <div className="mx-auto w-full max-w-3xl px-4 py-6 text-sm text-muted">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+              <div>
+                ⚠️ Cet outil aide uniquement aux calculs infirmiers — il ne
+                remplace pas l'avis médical.
+              </div>
+              <div>© {new Date().getFullYear()} — Fait avec ❤️ pour Chloé</div>
             </div>
-            <div>© {new Date().getFullYear()} — Fait avec ❤️ pour Chloé</div>
           </div>
-        </div>
-      </footer>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -97,7 +97,7 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
   return (
     <section className="pt-6 sm:pt-8 mb-2">
       {/* Ligne de contexte (ton + date + emoji météo discret) */}
-      <div className="flex flex-wrap items-center gap-2 text-[13px] uppercase tracking-wider text-slate-500">
+      <div className="flex flex-wrap items-center gap-2 text-[13px] uppercase tracking-wider text-muted">
         <span className="inline-flex items-center gap-1">
           <span aria-hidden>{wxIcon}</span>
           <span>{baseTone}</span>
@@ -108,13 +108,13 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
 
       {/* Titre sobre avec gradient léger */}
       <h2 className="mt-2 text-3xl sm:text-4xl font-extrabold leading-tight font-display">
-        <span className="bg-gradient-to-r from-brand-700 via-brand-600 to-cyan-600 bg-clip-text text-transparent">
+        <span className="bg-gradient-to-r from-moss via-primary to-mint bg-clip-text text-transparent">
           {dynamicTitle}
         </span>
       </h2>
 
       {/* Sous-texte concis */}
-      <p className="mt-2 text-slate-600">
+      <p className="mt-2 text-muted">
         Calculs rapides, repères utiles et outils patients.
         <span className="hidden sm:inline">
           {' '}
@@ -143,11 +143,11 @@ export function Tabs({
 
   const cls = (is: boolean) =>
     [
-      'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500/20',
+      'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-ring',
       'flex items-center justify-center gap-2 px-3 py-2 text-sm',
       is
-        ? 'bg-gradient-to-r from-brand-600 to-cyan-500 text-white border-transparent shadow'
-        : 'bg-white/60 hover:bg-white text-slate-700 border-white/60',
+        ? 'bg-gradient-to-r from-primary to-mint text-primary-foreground border-transparent shadow-e2'
+        : 'bg-surface hover:bg-surface/80 text-muted border-border',
     ].join(' ');
 
   return (

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -3,60 +3,70 @@
 
 import type { TabKey } from './App';
 
+function Sun() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <circle cx="12" cy="12" r="5" />
+      <path d="M12 1v2" />
+      <path d="M12 21v2" />
+      <path d="M4.22 4.22l1.42 1.42" />
+      <path d="M18.36 18.36l1.42 1.42" />
+      <path d="M1 12h2" />
+      <path d="M21 12h2" />
+      <path d="M4.22 19.78l1.42-1.42" />
+      <path d="M18.36 5.64l1.42-1.42" />
+    </svg>
+  );
+}
+
+function Moon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+  );
+}
+
 export function Header({
   onChangeTab,
   active,
+  dark,
+  onToggleDark,
 }: {
   onChangeTab: (t: TabKey) => void;
   active: TabKey;
+  dark: boolean;
+  onToggleDark: () => void;
 }) {
   return (
-    <header className="sticky top-0 z-40 backdrop-blur-xl bg-white/60 border-b border-white/40">
+    <header className="sticky top-0 z-40 bg-surface/70 backdrop-blur-md shadow-e2 border-b border-border">
       <div className="mx-auto w-full max-w-3xl px-4 py-3 flex items-center justify-between">
         <h1 className="text-xl sm:text-2xl font-semibold tracking-tight font-display">
           <span className="inline-flex items-center gap-2">
-            <span
-              className="inline-block h-6 w-6 rounded-xl bg-gradient-to-br from-brand-500 to-cyan-500"
-              aria-hidden
-            />
+            <span className="inline-block h-6 w-6 rounded-xl bg-primary" aria-hidden />
             <span>Outils de Chloé</span>
           </span>
         </h1>
-        <nav
-          className="hidden sm:flex gap-2 text-sm"
-          aria-label="Navigation principale"
-        >
-          <TopLink
-            id="calculs"
-            label="Calculs"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="gaz"
-            label="Gazométrie"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="patient"
-            label="Patient"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="notes"
-            label="Notes"
-            active={active}
-            onClick={onChangeTab}
-          />
-          <TopLink
-            id="apropos"
-            label="À propos"
-            active={active}
-            onClick={onChangeTab}
-          />
-        </nav>
+        <div className="flex items-center gap-2">
+          <nav
+            className="hidden sm:flex gap-2 text-sm"
+            aria-label="Navigation principale"
+          >
+            <TopLink id="calculs" label="Calculs" active={active} onClick={onChangeTab} />
+            <TopLink id="gaz" label="Gazométrie" active={active} onClick={onChangeTab} />
+            <TopLink id="patient" label="Patient" active={active} onClick={onChangeTab} />
+            <TopLink id="notes" label="Notes" active={active} onClick={onChangeTab} />
+            <TopLink id="apropos" label="À propos" active={active} onClick={onChangeTab} />
+          </nav>
+          <button
+            onClick={onToggleDark}
+            aria-label="Changer de thème"
+            className="p-2 rounded-full hover:bg-surface focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-pressed={dark}
+          >
+            {dark ? <Sun /> : <Moon />}
+          </button>
+        </div>
       </div>
     </header>
   );
@@ -77,10 +87,10 @@ export function TopLink({
   return (
     <button
       onClick={() => onClick(id)}
-      className={`px-3 py-1.5 rounded-full border transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-brand-500/20 hover:scale-105 active:scale-95 ${
+      className={`px-3 py-1.5 rounded-full border transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-ring hover:scale-105 active:scale-95 ${
         is
-          ? 'bg-gradient-to-r from-brand-600 to-cyan-500 text-white border-transparent shadow'
-          : 'bg-white/60 hover:bg-white text-slate-700 border-white/60'
+          ? 'bg-gradient-to-r from-primary to-mint text-primary-foreground border-transparent shadow-e2'
+          : 'bg-surface hover:bg-surface/80 text-muted border-border'
       }`}
       aria-current={is ? 'page' : undefined}
     >
@@ -108,7 +118,7 @@ export function BottomNav({
       className="fixed bottom-0 inset-x-0 z-40 sm:hidden"
       aria-label="Navigation mobile"
     >
-      <div className="mx-auto max-w-3xl bg-white/60 backdrop-blur-xl border-t border-white/40">
+      <div className="mx-auto max-w-3xl bg-surface/70 backdrop-blur-md border-t border-border shadow-e2">
         <div className="grid grid-cols-5">
           {items.map((t) => {
             const is = active === t.id;
@@ -116,8 +126,8 @@ export function BottomNav({
               <button
                 key={t.id}
                 onClick={() => onChange(t.id)}
-                className={`flex flex-col items-center justify-center py-2 text-xs transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-brand-500/20 hover:scale-105 active:scale-95 ${
-                  is ? 'text-brand-600' : 'text-slate-500'
+                className={`flex flex-col items-center justify-center py-2 text-xs transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-ring hover:scale-105 active:scale-95 ${
+                  is ? 'text-primary' : 'text-muted'
                 }`}
                 aria-current={is ? 'page' : undefined}
               >

--- a/src/Sprout.tsx
+++ b/src/Sprout.tsx
@@ -1,0 +1,29 @@
+export type SproutMood = 'happy' | 'sad' | 'rainy';
+
+export function Sprout({ mood = 'happy', className }: { mood?: SproutMood; className?: string }) {
+  const mouth = mood === 'sad' ? 'M9 18q3 2 6 0' : 'M9 18q3 -2 6 0';
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={"h-8 w-8 " + (className ?? 'text-primary')}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M12 22v-7" />
+      <path d="M9 15v-4a3 3 0 0 1 6 0v4" />
+      <path d="M5 15v-2a2 2 0 0 1 4 0v2" />
+      <path d="M15 15v-2a2 2 0 0 1 4 0v2" />
+      <path d="M5 22h14" />
+      <circle cx="10" cy="17" r="0.5" fill="currentColor" />
+      <circle cx="14" cy="17" r="0.5" fill="currentColor" />
+      <path d={mouth} />
+      {mood === 'rainy' && (
+        <path d="M19 3v2m-2-1h4" strokeWidth={1} />
+      )}
+    </svg>
+  );
+}

--- a/src/WeatherWidget.tsx
+++ b/src/WeatherWidget.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
+import ReactAnimatedWeather from 'react-animated-weather';
 import { useReducedMotion } from './ui/motion/ReducedMotion';
+import { Sprout } from './Sprout';
 
 type Weather = {
   location: string;
@@ -10,59 +12,27 @@ type Weather = {
 type Props = {
   city?: string;
   onWeather?: (w: Weather | null) => void;
+  showSprout?: boolean;
 };
 
-function iconFor(condition: string) {
+function skycon(condition: string) {
   const c = condition.toLowerCase();
-  if (c.includes('pluie'))
-    return (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <path d="M4 16.5a4.5 4.5 0 0 1 1-8.9 5.5 5.5 0 0 1 10.9 1.4 4 4 0 0 1 2.1 7.5" />
-        <path d="M16 13v3" />
-        <path d="M12 16v3" />
-        <path d="M8 13v3" />
-      </svg>
-    );
-  if (c.includes('neige'))
-    return (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <path d="M12 2v20" />
-        <path d="M4.93 6.93l14.14 14.14" />
-        <path d="M4.93 21.07L19.07 6.93" />
-        <path d="M2 12h20" />
-      </svg>
-    );
-  if (c.includes('nuage'))
-    return (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <path d="M17.5 19a4.5 4.5 0 0 0-.9-8.9A5.5 5.5 0 0 0 6 9.5a4 4 0 0 0 1 7.9h10.5z" />
-      </svg>
-    );
-  if (c.includes('orage'))
-    return (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <path d="M13 16l-3 5" />
-        <path d="M13 16l4-8" />
-        <path d="M3 13a4 4 0 0 1 2-7.5 5.5 5.5 0 0 1 10.9 1.4 4 4 0 0 1 2.1 7.5" />
-      </svg>
-    );
-  // default sun
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-      <circle cx="12" cy="12" r="5" />
-      <path d="M12 1v2" />
-      <path d="M12 21v2" />
-      <path d="M4.22 4.22l1.42 1.42" />
-      <path d="M18.36 18.36l1.42 1.42" />
-      <path d="M1 12h2" />
-      <path d="M21 12h2" />
-      <path d="M4.22 19.78l1.42-1.42" />
-      <path d="M18.36 5.64l1.42-1.42" />
-    </svg>
-  );
+  if (c.includes('pluie')) return 'RAIN';
+  if (c.includes('neige')) return 'SNOW';
+  if (c.includes('nuage')) return 'CLOUDY';
+  if (c.includes('orage')) return 'WIND';
+  return 'CLEAR_DAY';
 }
 
-export function WeatherWidget({ city = 'Solliès-Toucas', onWeather }: Props) {
+function bgFor(condition: string) {
+  const c = condition.toLowerCase();
+  if (c.includes('pluie')) return 'rain';
+  if (c.includes('neige')) return 'snow';
+  if (c.includes('nuage')) return 'cloud';
+  return 'sun';
+}
+
+export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout }: Props) {
   const [data, setData] = useState<Weather | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -104,7 +74,7 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather }: Props) {
   if (loading) {
     return (
       <div
-        className={`mt-2 h-8 w-32 rounded bg-white/50 ${prefersReduced ? '' : 'animate-pulse'}`}
+        className={`mt-4 h-24 w-full rounded-2xl bg-card border border-border ${prefersReduced ? '' : 'animate-pulse'}`}
         aria-hidden
       />
     );
@@ -112,18 +82,40 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather }: Props) {
 
   if (error || !data) {
     return (
-      <div className="mt-2 text-sm text-slate-500" role="status">
+      <div className="mt-4 text-sm text-muted" role="status">
         {error || 'Météo indisponible'}
       </div>
     );
   }
 
+  const cond = data.condition.toLowerCase();
+  const mood = cond.includes('pluie') ? 'rainy' : 'happy';
+  const message = cond.includes('pluie')
+    ? 'La nature boit la pluie.'
+    : 'Belle journée verdoyante.';
+  const bg = bgFor(data.condition);
+  const icon = skycon(data.condition);
+
   return (
-    <div className="mt-2 flex items-center gap-2 text-slate-700">
-      <span aria-hidden>{iconFor(data.condition)}</span>
-      <span className="text-sm">
-        {Math.round(data.temp)}°C — {data.condition}
-      </span>
+    <div className={`relative mt-4 flex items-center justify-between overflow-hidden rounded-2xl p-4 shadow-e2 border border-border text-white weather-${bg}`}>
+      <div className="flex items-center gap-3">
+        <ReactAnimatedWeather
+          icon={icon}
+          color="#fff"
+          size={48}
+          animate={!prefersReduced}
+        />
+        <div>
+          <div className="text-2xl font-bold">{Math.round(data.temp)}°C</div>
+          <div className="text-sm opacity-90">{data.condition}</div>
+          <div className="text-xs opacity-80">{message}</div>
+        </div>
+      </div>
+      {showSprout && (
+        <span className="ml-2">
+          <Sprout mood={mood} />
+        </span>
+      )}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,64 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+:root {
+  --color-bg: #f6f9f7;
+  --color-surface: #ffffff;
+  --color-card: #f0f5f2;
+  --color-primary: #166534;
+  --color-primary-fg: #ffffff;
+  --color-fg: #1f2937;
+  --color-muted: #4b5563;
+  --color-border: #d1d5db;
+  --color-ring: #16a34a;
+  --color-success: #16a34a;
+  --color-warn: #ca8a04;
+  --color-danger: #dc2626;
+  --color-info: #0ea5e9;
+  --color-mint: #a7f3d0;
+  --color-moss: #4d7c0f;
+}
+
+.dark {
+  --color-bg: #0d1b14;
+  --color-surface: #16281d;
+  --color-card: #1d3425;
+  --color-primary: #4ade80;
+  --color-primary-fg: #0d1b14;
+  --color-fg: #e5e7eb;
+  --color-muted: #9ca3af;
+  --color-border: #2e4b35;
+  --color-ring: #34d399;
+  --color-success: #22c55e;
+  --color-warn: #eab308;
+  --color-danger: #f87171;
+  --color-info: #38bdf8;
+  --color-mint: #34d399;
+  --color-moss: #a3e635;
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath d='M0 0h40v40H0z' fill='%23000000' fill-opacity='0.02'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.03;
+  pointer-events: none;
+  z-index: -1;
+}
+
+@media (prefers-contrast: more) {
+  body::before {
+    display: none;
+  }
+}
+
 #root {
   min-height: 100vh;
 }
@@ -33,6 +91,72 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-ring);
   outline-offset: 2px;
+}
+
+/* Animations météo */
+@keyframes weatherGradient {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 100% 50%;
+  }
+}
+
+@keyframes rainDrop {
+  from {
+    transform: translateY(-10px);
+  }
+  to {
+    transform: translateY(10px);
+  }
+}
+
+.weather-sun,
+.weather-rain,
+.weather-cloud,
+.weather-snow {
+  background-size: 200% 200%;
+  animation: weatherGradient 20s ease infinite;
+}
+
+.weather-sun {
+  background-image: linear-gradient(-45deg, #fefce8, #d9f99d, #86efac, #a7f3d0);
+}
+
+.weather-cloud {
+  background-image: linear-gradient(-45deg, #e5e7eb, #f3f4f6, #d1d5db, #e5e7eb);
+}
+
+.weather-rain {
+  background-image: linear-gradient(-45deg, #c7d2fe, #93c5fd, #60a5fa, #3b82f6);
+}
+
+.weather-rain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle at 2px 2px, rgba(255,255,255,0.4) 1px, transparent 1.5px);
+  background-size: 8px 8px;
+  animation: rainDrop 0.6s linear infinite;
+  pointer-events: none;
+  opacity: 0.2;
+}
+
+.weather-snow {
+  background-image: linear-gradient(-45deg, #e0f2fe, #bae6fd, #f0f9ff, #e0f2fe);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-sun,
+  .weather-rain,
+  .weather-cloud,
+  .weather-snow {
+    animation: none;
+  }
+  .weather-rain::after {
+    animation: none;
+  }
 }

--- a/src/tabs/Calculs.tsx
+++ b/src/tabs/Calculs.tsx
@@ -24,7 +24,7 @@ function QuickPanel() {
   const [c, setC] = useState<number>(10);
   const ml = safeDiv(Number(w) * Number(d), Number(c));
   return (
-    <div className="rounded-3xl border bg-white p-4">
+    <div className="rounded-2xl border border-border bg-card p-4">
       <div className="text-sm font-medium mb-2">Raccourci: dose mg/kg → mL</div>
       <div className="grid grid-cols-3 gap-2 mb-3">
         <MiniField label="Poids" value={w} suffix="kg" onChange={(v) => setW(Number(v))} />
@@ -36,7 +36,7 @@ function QuickPanel() {
           onChange={(v) => setC(Number(v))}
         />
       </div>
-      <div className="rounded-xl border bg-slate-50 text-slate-800 px-3 py-2 text-sm">≈ {round(ml)} mL</div>
+      <div className="rounded-xl border border-border bg-surface px-3 py-2 text-sm text-muted">≈ {round(ml)} mL</div>
     </div>
   );
 }
@@ -83,7 +83,11 @@ function DoseCalculator() {
           <button
             key={m.id}
             onClick={() => setMode(m.id)}
-            className={`px-3 py-1.5 rounded-full text-sm border whitespace-nowrap ${mode === m.id ? "bg-slate-900 text-white border-slate-900" : "bg-white hover:bg-slate-50"}`}
+            className={`px-3 py-1.5 rounded-full text-sm border whitespace-nowrap ${
+              mode === m.id
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-surface text-muted border-border hover:bg-card"
+            }`}
           >
             {m.label}
           </button>
@@ -158,11 +162,11 @@ function DoseCalculator() {
             onChange={(v) => setDoseSouhaitee(Number(v))}
             suffix="mg"
           />
-          <Result tone="info">{res.text}</Result>
+          <Result>{res.text}</Result>
         </div>
       )}
 
-      <div className="text-xs text-slate-500 mt-3">Double contrôle recommandé.</div>
+      <div className="text-xs text-muted mt-3">Double contrôle recommandé.</div>
     </Card>
   );
 }
@@ -240,15 +244,15 @@ function DripRate() {
 function MiniField({ label, value, onChange, suffix }: { label: string; value: number; onChange: (v: number) => void; suffix?: string }) {
   return (
     <label className="block">
-      <div className="text-[11px] text-slate-600">{label}</div>
+      <div className="text-[11px] text-muted">{label}</div>
       <div className="flex items-center gap-1">
         <input
-          className="w-full rounded-lg border px-2 py-1 text-sm"
+          className="w-full rounded-lg border border-border bg-surface px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           type="number"
           value={value}
           onChange={(e) => onChange(toNum(e.target.value))}
         />
-        <span className="text-[11px] text-slate-500">{suffix}</span>
+        <span className="text-[11px] text-muted">{suffix}</span>
       </div>
     </label>
   );

--- a/src/tabs/Gazometrie.tsx
+++ b/src/tabs/Gazometrie.tsx
@@ -92,11 +92,11 @@ function ABGTool() {
     [pH, PaCO2, HCO3]
   );
 
-  const pfTone: 'ok' | 'warn' | 'danger' | 'info' =
-    pf >= 300 ? 'ok' : pf >= 200 ? 'info' : pf >= 100 ? 'warn' : 'danger';
-  const lactTone: 'ok' | 'warn' | 'danger' =
+  const pfTone: 'success' | 'warn' | 'danger' | 'info' =
+    pf >= 300 ? 'success' : pf >= 200 ? 'info' : pf >= 100 ? 'warn' : 'danger';
+  const lactTone: 'success' | 'warn' | 'danger' =
     Number.isFinite(lactate) && lactate <= 2
-      ? 'ok'
+      ? 'success'
       : Number.isFinite(lactate) && lactate <= 4
       ? 'warn'
       : 'danger';
@@ -118,8 +118,8 @@ function ABGTool() {
 
   return (
     <Card title="Gazométrie (ABG)" subtitle="Aide à l'interprétation rapide">
-      <fieldset className="rounded-2xl border p-3">
-        <legend className="px-2 text-xs text-slate-600">Gaz du sang</legend>
+      <fieldset className="rounded-2xl border border-border p-3">
+        <legend className="px-2 text-xs text-muted">Gaz du sang</legend>
         <div className="grid grid-cols-2 gap-3">
           <FieldStr
             label="pH"
@@ -158,8 +158,8 @@ function ABGTool() {
         </div>
       </fieldset>
 
-      <fieldset className="rounded-2xl border p-3 mt-3">
-        <legend className="px-2 text-xs text-slate-600">Électrolytes</legend>
+      <fieldset className="rounded-2xl border border-border p-3 mt-3">
+        <legend className="px-2 text-xs text-muted">Électrolytes</legend>
         <div className="grid grid-cols-2 gap-3">
           <FieldStr
             label="Na⁺"
@@ -199,7 +199,7 @@ function ABGTool() {
       </fieldset>
 
       <details className="mt-3">
-        <summary className="text-xs text-slate-600 cursor-pointer">
+        <summary className="text-xs text-muted cursor-pointer">
           Options avancées (altitude & physiologie)
         </summary>
         <div className="grid grid-cols-2 gap-3 mt-2">
@@ -232,13 +232,13 @@ function ABGTool() {
         </div>
         <div className="flex gap-2">
           <button
-            className="px-3 py-2 rounded-xl border text-sm hover:bg-slate-50"
+            className="px-3 py-2 rounded-xl border border-border bg-surface text-sm hover:bg-card"
             onClick={onCopy}
           >
             Copier le résumé
           </button>
         </div>
-        <div className="text-[11px] text-slate-500">
+        <div className="text-[11px] text-muted">
           Repères: pH 7.35–7.45 ; PaCO₂ 35–45 ; HCO₃⁻ 22–26 ; P/F ≥ 300 ; AG
           normal ~8–12 (non corrigé) ; lactate ≤ 2.
         </div>

--- a/src/tabs/PatientNotes.tsx
+++ b/src/tabs/PatientNotes.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from 'react';
 
-import { Card, Field, Result } from '../ui/UI';
+import { Card, Field, Result, Select } from '../ui/UI';
 import { round, safeDiv } from '../utils';
 
 export function PatientTab() {
@@ -30,7 +30,7 @@ export function AProposTab() {
         title="À propos"
         subtitle="Conçu pour Chloé — usage d’aide uniquement"
       >
-        <p className="text-sm text-slate-700">
+        <p className="text-sm text-muted">
           Toujours vérifier selon le protocole local et réaliser un double
           contrôle pour les calculs. Créé avec ❤️ pour Chloé.
         </p>
@@ -68,32 +68,34 @@ function CrCl() {
           onChange={(v) => setPoids(Number(v))}
           suffix="kg"
         />
-        <select
-          className="w-full rounded-xl border px-3 py-2 text-base"
+        <Select
+          label="Sexe"
           value={sexe}
-          onChange={(e) => setSexe(e.target.value as 'F' | 'M')}
-        >
-          <option value="F">Femme</option>
-          <option value="M">Homme</option>
-        </select>
-        <select
-          className="w-full rounded-xl border px-3 py-2 text-base"
+          onChange={(v) => setSexe(v as 'F' | 'M')}
+          options={[
+            { v: 'F', l: 'Femme' },
+            { v: 'M', l: 'Homme' },
+          ]}
+        />
+        <Select
+          label="Unité"
           value={unit}
-          onChange={(e) => setUnit(e.target.value as 'umol' | 'mgdl')}
-        >
-          <option value="umol">µmol/L</option>
-          <option value="mgdl">mg/dL</option>
-        </select>
+          onChange={(v) => setUnit(v as 'umol' | 'mgdl')}
+          options={[
+            { v: 'umol', l: 'µmol/L' },
+            { v: 'mgdl', l: 'mg/dL' },
+          ]}
+        />
         <Field
           label={`Créatinine sérique (${unit === 'umol' ? 'µmol/L' : 'mg/dL'})`}
           value={scr}
           onChange={(v) => setScr(Number(v))}
         />
       </div>
-      <Result tone="info">
+      <Result>
         CrCl ≈ <b>{round(crcl)}</b> mL/min
       </Result>
-      <div className="text-[11px] text-slate-500 mt-2">
+      <div className="text-[11px] text-muted mt-2">
         Vérifier la posologie selon protocole local.
       </div>
     </Card>
@@ -164,7 +166,7 @@ function NoteBlock() {
       subtitle="Sauvegardez localement vos repères (reste dans ce navigateur)"
     >
       <textarea
-        className="w-full rounded-xl border p-3 focus:outline-none focus:ring-2 focus:ring-slate-900/20"
+        className="w-full rounded-xl border border-border bg-surface p-3 focus:outline-none focus:ring-2 focus:ring-ring"
         placeholder="Écrire une note et appuyer sur Entrée"
         value={input}
         onChange={(e) => setInput(e.target.value)}
@@ -180,14 +182,14 @@ function NoteBlock() {
           {notes.map((n, i) => (
             <li
               key={i}
-              className="rounded-lg border px-3 py-2 text-sm bg-white/70"
+              className="rounded-lg border border-border bg-card/70 px-3 py-2 text-sm"
             >
               {n}
             </li>
           ))}
         </ul>
       )}
-      <div className="text-[11px] text-slate-500 mt-2">
+      <div className="text-[11px] text-muted mt-2">
         Astuce: <em>Ctrl/Cmd + P</em> pour imprimer la page / exporter en PDF.
       </div>
     </Card>

--- a/src/tests/Tests.tsx
+++ b/src/tests/Tests.tsx
@@ -11,6 +11,7 @@ import {
   celsiusToFahrenheit,
   fahrenheitToCelsius,
 } from '../utils';
+import { StatusBadge } from '../ui/StatusBadge';
 
 export function Tests() {
   const cases = [
@@ -81,21 +82,20 @@ export function Tests() {
 
   return (
     <section className="mt-6">
-      <details className="rounded-2xl border bg-white p-4">
-        <summary
-          className={`cursor-pointer select-none text-sm font-medium ${
-            allPass ? 'text-emerald-700' : 'text-rose-700'
-          }`}
-        >
-          Tests intégrés: {allPass ? 'OK' : 'ÉCHEC'}
+      <details className="rounded-2xl border border-border bg-card p-4">
+        <summary className="cursor-pointer select-none text-sm font-medium flex items-center gap-2">
+          Tests intégrés:
+          <StatusBadge status={allPass ? 'success' : 'danger'} label={allPass ? 'OK' : 'ÉCHEC'} />
         </summary>
         <ul className="mt-3 space-y-2 text-sm">
           {cases.map((t, i) => (
             <li key={i} className="flex items-center justify-between">
               <span>{t.name}</span>
-              <span className={t.pass ? 'text-emerald-700' : 'text-rose-700'}>
-                attendu {round(t.expected)} / obtenu {round(t.actual)} —{' '}
-                {t.pass ? 'OK' : 'KO'}
+              <span className="flex items-center gap-2">
+                <span>
+                  attendu {round(t.expected)} / obtenu {round(t.actual)}
+                </span>
+                <StatusBadge status={t.pass ? 'success' : 'danger'} label={t.pass ? 'OK' : 'KO'} />
               </span>
             </li>
           ))}

--- a/src/types/react-animated-weather.d.ts
+++ b/src/types/react-animated-weather.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-animated-weather';

--- a/src/ui/StatusBadge.tsx
+++ b/src/ui/StatusBadge.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+
+type Status = 'success' | 'warn' | 'danger' | 'info';
+
+const icons: Record<Status, ReactNode> = {
+  success: (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="m5 13 4 4L19 7" />
+    </svg>
+  ),
+  warn: (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+    </svg>
+  ),
+  danger: (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="m18 6-12 12" />
+      <path d="m6 6 12 12" />
+    </svg>
+  ),
+  info: (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  ),
+};
+
+const styles: Record<Status, string> = {
+  success: 'text-success bg-success/10 border-success/20',
+  warn: 'text-warn bg-warn/10 border-warn/20',
+  danger: 'text-danger bg-danger/10 border-danger/20',
+  info: 'text-info bg-info/10 border-info/20',
+};
+
+export function StatusBadge({ status, label }: { status: Status; label: string }) {
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${styles[status]}`}>
+      {icons[status]}
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -15,12 +15,12 @@ export function Card({
 }) {
   return (
     <section
-      className="rounded-3xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow"
+      className="rounded-2xl border border-border bg-card p-5 shadow-e1 hover:shadow-e2 transition-shadow"
       aria-label={title}
     >
       <div className="mb-4">
         <h3 className="text-lg font-semibold tracking-tight">{title}</h3>
-        {subtitle && <p className="text-sm text-slate-600 mt-1">{subtitle}</p>}
+        {subtitle && <p className="text-sm text-muted mt-1">{subtitle}</p>}
       </div>
       {children}
     </section>
@@ -53,11 +53,11 @@ export function Field({
   const id = React.useId();
   return (
     <label className="block mb-3" htmlFor={id}>
-      <div className="text-sm text-slate-700 mb-1">{label}</div>
+      <div className="text-sm text-muted mb-1">{label}</div>
       <div className="flex items-center gap-2">
         <input
           id={id}
-          className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20"
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type={type}
           inputMode={type === 'number' ? 'decimal' : undefined}
           value={value}
@@ -73,7 +73,7 @@ export function Field({
             )
           }
         />
-        {suffix && <div className="text-sm text-slate-500">{suffix}</div>}
+        {suffix && <div className="text-sm text-muted">{suffix}</div>}
       </div>
     </label>
   );
@@ -95,23 +95,23 @@ export function FieldStr({
   const id = React.useId();
   return (
     <label className="block mb-3" htmlFor={id}>
-      <div className="text-sm text-slate-700 mb-1">{label}</div>
+      <div className="text-sm text-muted mb-1">{label}</div>
       <div className="flex items-center gap-2">
         <input
           id={id}
-          className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20"
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type="text"
           inputMode="decimal"
           value={value}
           placeholder={placeholder}
           onChange={(e) => onChange(e.target.value)}
         />
-        {suffix && <div className="text-sm text-slate-500">{suffix}</div>}
+        {suffix && <div className="text-sm text-muted">{suffix}</div>}
         {value !== '' && (
           <button
             type="button"
             aria-label="Effacer"
-            className="text-slate-500 text-sm px-2 py-1 rounded-lg border hover:bg-slate-50"
+            className="text-muted text-sm px-2 py-1 rounded-md border border-border hover:bg-surface"
             onClick={() => onChange('')}
           >
             ×
@@ -136,9 +136,9 @@ export function Select({
 }) {
   return (
     <label className="block mb-3">
-      <div className="text-sm text-slate-700 mb-1">{label}</div>
+      <div className="text-sm text-muted mb-1">{label}</div>
       <select
-        className="w-full rounded-xl border px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-slate-900/20 bg-white"
+        className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
         value={String(value)}
         onChange={(e) =>
           onChange(
@@ -169,7 +169,7 @@ export function Toggle({ label, checked, onChange }: ToggleProps) {
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
       />
-      <span className="text-sm text-slate-700">{label}</span>
+      <span className="text-sm text-muted">{label}</span>
     </label>
   );
 }
@@ -179,18 +179,16 @@ export function Chip({
   tone = 'info',
 }: {
   children: React.ReactNode;
-  tone?: 'ok' | 'warn' | 'danger' | 'info';
+  tone?: 'success' | 'warn' | 'danger' | 'info';
 }) {
-  const map: Record<'ok' | 'warn' | 'danger' | 'info', string> = {
-    ok: 'bg-emerald-50 text-emerald-700 border-emerald-200',
-    warn: 'bg-amber-50 text-amber-700 border-amber-200',
-    danger: 'bg-rose-50 text-rose-700 border-rose-200',
-    info: 'bg-slate-50 text-slate-700 border-slate-200',
+  const map: Record<'success' | 'warn' | 'danger' | 'info', string> = {
+    success: 'bg-success/10 text-success border-success/20',
+    warn: 'bg-warn/10 text-warn border-warn/20',
+    danger: 'bg-danger/10 text-danger border-danger/20',
+    info: 'bg-info/10 text-info border-info/20',
   };
   return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 ${map[tone]}`}
-    >
+    <span className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 ${map[tone]}`}>
       {children}
     </span>
   );
@@ -198,7 +196,7 @@ export function Chip({
 
 export function Badge({ label }: { label: string }) {
   return (
-    <div className="text-xs rounded-full border px-2 py-1 bg-slate-50 text-slate-700">
+    <div className="text-xs rounded-full border border-border px-2 py-1 bg-surface text-muted">
       {label}
     </div>
   );
@@ -206,18 +204,18 @@ export function Badge({ label }: { label: string }) {
 
 export function Result({
   children,
-  tone = 'ok',
+  tone = 'success',
 }: {
   children: React.ReactNode;
-  tone?: 'ok' | 'warn' | 'danger' | 'info';
+  tone?: 'success' | 'warn' | 'danger' | 'info';
 }) {
-  const toneMap: Record<'ok' | 'warn' | 'danger' | 'info', string> = {
-    ok: 'bg-emerald-50 text-emerald-700 border-emerald-200',
-    warn: 'bg-amber-50 text-amber-700 border-amber-200',
-    danger: 'bg-rose-50 text-rose-700 border-rose-200',
-    info: 'bg-slate-50 text-slate-700 border-slate-200',
+  const toneMap: Record<'success' | 'warn' | 'danger' | 'info', string> = {
+    success: 'bg-success/10 text-success border-success/20',
+    warn: 'bg-warn/10 text-warn border-warn/20',
+    danger: 'bg-danger/10 text-danger border-danger/20',
+    info: 'bg-info/10 text-info border-info/20',
   };
-  const styles = toneMap[tone] || toneMap.ok;
+  const styles = toneMap[tone] || toneMap.success;
   return (
     <div className={`rounded-2xl border px-4 py-3 text-sm ${styles}`}>
       {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,40 @@
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--color-bg)",
+        surface: "var(--color-surface)",
+        card: "var(--color-card)",
+        primary: {
+          DEFAULT: "var(--color-primary)",
+          foreground: "var(--color-primary-fg)",
+        },
+        foreground: "var(--color-fg)",
+        muted: "var(--color-muted)",
+        border: "var(--color-border)",
+        ring: "var(--color-ring)",
+        success: "var(--color-success)",
+        warn: "var(--color-warn)",
+        danger: "var(--color-danger)",
+        info: "var(--color-info)",
+        mint: "var(--color-mint)",
+        moss: "var(--color-moss)",
+      },
+      borderRadius: {
+        sm: "4px",
+        md: "8px",
+        xl: "16px",
+        "2xl": "24px",
+      },
+      boxShadow: {
+        e1: "0 1px 2px 0 rgb(0 0 0 / 0.04)",
+        e2: "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+        e3: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+        e4: "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add Verdant Care design tokens and shadows
- refresh AppShell with frosty header and dark/light toggles
- introduce weather card, status badges, and Sprout mascot
- fix dark-mode styles for dose calculator and patient selects
- improve light-mode contrast and animate weather widget backgrounds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689deefca8588332b1ae5e2e42f895f0