### PR TITLE
Generalize branding, add Open-Meteo fallback, enhance notes UI and input handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ export default function NurseToolkitApp() {
                 ⚠️ Cet outil aide uniquement aux calculs infirmiers — il ne
                 remplace pas l'avis médical.
               </div>
-              <div>© {new Date().getFullYear()} — Fait avec ❤️ pour Chloé</div>
+              <div>© {new Date().getFullYear()} — NurseTools</div>
             </div>
           </div>
         </footer>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -42,38 +42,38 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
 
   const dynamicTitle = useMemo(() => {
     if (cond.includes('tempête'))
-      return '🌪 Tempête dehors, sérénité dedans grâce à toi, ma héroïne.';
+      return '🌪 Tempête dehors, gardez le cap avec des repères fiables.';
     if (cond.includes('grêle'))
-      return '🌨 Les grêlons tapent, mais tu gardes la réa au chaud.';
+      return '🌨 Conditions difficiles : priorisez la sécurité des soins.';
     if (cond.includes('vent'))
-      return '💨 Vent fou, ton calme en réa ne vacille jamais, ma Chloé.';
+      return '💨 Vent soutenu : restez méthodique et précis.';
     if (cond.includes('bruine'))
-      return '🌦 Bruine légère, parfait pour un câlin avant la garde.';
+      return '🌦 Bruine légère : journée idéale pour une garde sereine.';
     if (cond.includes('pluie'))
-      return '🌧 Un peu de pluie dehors, mais du soleil dans ton cœur.';
+      return '🌧 Pluie dehors, rigueur et clarté dedans.';
     if (cond.includes('neige'))
-      return '❄️ Temps parfait pour un chocolat chaud sous un plaid.';
+      return '❄️ Temps froid : anticipez l’organisation de la garde.';
     if (cond.includes('orage'))
-      return '⛈ Calme dans la tempête, Chloé.';
+      return '⛈ Restez calme et structuré dans la tempête.';
     if (cond.includes('brouillard'))
       return '🌫 Horizon flou, mission claire.';
     if (cond.includes('nuage'))
       return '🌤 Un temps doux pour adoucir la garde.';
     if (cond.includes('soleil') || cond.includes('ensoleillé'))
-      return '☀️ Un grand soleil pour éclairer ta journée, Chloé !';
+      return '☀️ Belle luminosité pour une journée productive.';
     if (temp !== undefined) {
       if (temp >= 35)
         return '🔥 Canicule en vue, pense à bien t’hydrater.';
       if (temp >= 30)
-        return '🥵 Grosse chaleur, j’ai glissé une bouteille fraîche dans ton sac.';
+        return '🥵 Grosse chaleur : hydratez-vous régulièrement.';
       if (temp >= 25)
         return '🌡 Il fait chaud, courage pour la garde.';
       if (temp >= 15)
-        return '🌼 Douce température, ton sourire rassure toute la réa.';
+        return '🌼 Douce température, conditions confortables.';
       if (temp >= 10)
-        return '🍂 Petit air frais, je t’ai laissé un pull dans le casier.';
+        return '🍂 Petit air frais, pensez à vous couvrir.';
       if (temp <= -5)
-        return '🧊 Froid mordant, tu restes la flamme des soins intensifs.';
+        return '🧊 Froid marqué, adaptez la prise en charge logistique.';
       if (temp <= 0)
         return '🥶 Il fait glacial, couvre-toi bien !';
       if (temp < 10)
@@ -82,9 +82,9 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
     if (h >= 21 || h < 6)
       return '🌙 Douce nuit, prends soin de toi.';
     if (h >= 6 && h < 9)
-      return '🌅 Bonjour ma star de la réa, ton café t’attend.';
+      return '🌅 Bonjour, bonne prise de poste.';
     if (h >= 18 && h < 21)
-      return '🌆 Fin de garde en vue, je t’attends avec un gros câlin.';
+      return '🌆 Fin de garde en vue, pensez à la relève.';
     return '🌤 Un temps doux pour adoucir la garde.';
   }, [cond, temp, h]);
 

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -44,7 +44,7 @@ export function Header({
         <h1 className="text-xl sm:text-2xl font-semibold tracking-tight font-display">
           <span className="inline-flex items-center gap-2">
             <span className="inline-block h-6 w-6 rounded-xl bg-primary" aria-hidden />
-            <span>Outils de Chloé</span>
+            <span>NurseTools</span>
           </span>
         </h1>
         <div className="flex items-center gap-2">

--- a/src/WeatherWidget.tsx
+++ b/src/WeatherWidget.tsx
@@ -14,6 +14,22 @@ type Props = {
   showSprout?: boolean;
 };
 
+type OpenMeteoCurrent = {
+  temperature_2m: number;
+  weather_code: number;
+};
+
+function weatherCodeToFrenchLabel(code: number) {
+  if (code === 0) return 'Ensoleillé';
+  if ([1, 2, 3].includes(code)) return 'Nuageux';
+  if ([45, 48].includes(code)) return 'Brouillard';
+  if ([51, 53, 55, 56, 57].includes(code)) return 'Bruine';
+  if ([61, 63, 65, 66, 67, 80, 81, 82].includes(code)) return 'Pluie';
+  if ([71, 73, 75, 77, 85, 86].includes(code)) return 'Neige';
+  if ([95, 96, 99].includes(code)) return 'Orage';
+  return 'Conditions variables';
+}
+
 function iconFor(condition: string) {
   const c = condition.toLowerCase();
   if (c.includes('pluie'))
@@ -64,7 +80,7 @@ function iconFor(condition: string) {
   );
 }
 
-export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout }: Props) {
+export function WeatherWidget({ city = 'Paris', onWeather, showSprout }: Props) {
   const [data, setData] = useState<Weather | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -73,22 +89,38 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout 
   useEffect(() => {
     async function load() {
       const key = import.meta.env.VITE_WEATHER_API_KEY;
-      if (!key) {
-        setError('Clé API manquante');
-        onWeather?.(null);
-        setLoading(false);
-        return;
-      }
       try {
-        const url = `https://api.weatherapi.com/v1/current.json?key=${key}&q=${encodeURIComponent(city)}&lang=fr&aqi=no`;
-        const res = await fetch(url);
-        if (!res.ok) throw new Error('Erreur réseau');
-        const json = await res.json();
-        const w: Weather = {
-          location: json.location.name,
-          temp: json.current.temp_c,
-          condition: json.current.condition.text,
-        };
+        let w: Weather;
+        if (key) {
+          const url = `https://api.weatherapi.com/v1/current.json?key=${key}&q=${encodeURIComponent(city)}&lang=fr&aqi=no`;
+          const res = await fetch(url);
+          if (!res.ok) throw new Error('Erreur réseau');
+          const json = await res.json();
+          w = {
+            location: json.location.name,
+            temp: json.current.temp_c,
+            condition: json.current.condition.text,
+          };
+        } else {
+          const geoUrl = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1&language=fr&format=json`;
+          const geoRes = await fetch(geoUrl);
+          if (!geoRes.ok) throw new Error('Géocodage indisponible');
+          const geoJson = await geoRes.json();
+          const first = geoJson?.results?.[0];
+          if (!first) throw new Error('Ville introuvable');
+
+          const meteoUrl = `https://api.open-meteo.com/v1/forecast?latitude=${first.latitude}&longitude=${first.longitude}&current=temperature_2m,weather_code`;
+          const meteoRes = await fetch(meteoUrl);
+          if (!meteoRes.ok) throw new Error('Météo indisponible');
+          const meteoJson = await meteoRes.json();
+          const current = meteoJson?.current as OpenMeteoCurrent | undefined;
+          if (!current) throw new Error('Données météo invalides');
+          w = {
+            location: first.name,
+            temp: current.temperature_2m,
+            condition: weatherCodeToFrenchLabel(current.weather_code),
+          };
+        }
         setData(w);
         onWeather?.(w);
         setError(null);
@@ -136,6 +168,7 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout 
           <div className="text-2xl font-bold text-primary">
             {Math.round(data.temp)}°C
           </div>
+          <div className="text-sm text-muted">{data.location}</div>
           <div className="text-sm text-muted">{data.condition}</div>
           <div className="text-xs text-muted/80">{message}</div>
         </div>

--- a/src/tabs/PatientNotes.tsx
+++ b/src/tabs/PatientNotes.tsx
@@ -28,11 +28,12 @@ export function AProposTab() {
     <section className="mt-6 space-y-6">
       <Card
         title="À propos"
-        subtitle="Conçu pour Chloé — usage d’aide uniquement"
+        subtitle="Outils d’aide au calcul pour la pratique infirmière"
       >
         <p className="text-sm text-muted">
           Toujours vérifier selon le protocole local et réaliser un double
-          contrôle pour les calculs. Créé avec ❤️ pour Chloé.
+          contrôle pour les calculs. Cette application ne remplace pas un avis
+          médical.
         </p>
       </Card>
     </section>
@@ -160,6 +161,14 @@ function NoteBlock() {
     setInput('');
   };
 
+  const removeNote = (index: number) => {
+    saveNotes(notes.filter((_, i) => i !== index));
+  };
+
+  const clearNotes = () => {
+    saveNotes([]);
+  };
+
   return (
     <Card
       title="Bloc-notes rapide"
@@ -178,16 +187,35 @@ function NoteBlock() {
         }}
       />
       {notes.length > 0 && (
-        <ul className="mt-3 space-y-2">
-          {notes.map((n, i) => (
-            <li
-              key={i}
-              className="rounded-lg border border-border bg-card/70 px-3 py-2 text-sm"
+        <>
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              className="rounded-lg border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface"
+              onClick={clearNotes}
             >
-              {n}
-            </li>
-          ))}
-        </ul>
+              Tout effacer
+            </button>
+          </div>
+          <ul className="mt-2 space-y-2">
+            {notes.map((n, i) => (
+              <li
+                key={`${n}-${i}`}
+                className="rounded-lg border border-border bg-card/70 px-3 py-2 text-sm flex items-start justify-between gap-3"
+              >
+                <span>{n}</span>
+                <button
+                  type="button"
+                  aria-label={`Supprimer la note ${i + 1}`}
+                  className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted hover:bg-surface"
+                  onClick={() => removeNote(i)}
+                >
+                  Supprimer
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
       <div className="text-[11px] text-muted mt-2">
         Astuce: <em>Ctrl/Cmd + P</em> pour imprimer la page / exporter en PDF.

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -51,6 +51,10 @@ export function Field({
   placeholder,
 }: FieldProps) {
   const id = React.useId();
+  const normalizedValue =
+    type === 'number' && typeof value === 'number' && Number.isNaN(value)
+      ? ''
+      : value;
   return (
     <label className="block mb-3" htmlFor={id}>
       <div className="text-sm text-muted mb-1">{label}</div>
@@ -60,7 +64,7 @@ export function Field({
           className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type={type}
           inputMode={type === 'number' ? 'decimal' : undefined}
-          value={value}
+          value={normalizedValue}
           min={min}
           max={max}
           placeholder={placeholder}


### PR DESCRIPTION
### Motivation
- Remove personalized strings and replace them with neutral product branding and messaging for broader use. 
- Allow weather lookup to work without a proprietary API key by falling back to a free Open-Meteo flow. 
- Improve note management and make numeric form fields handle empty/NaN values gracefully.

### Description
- Replaced instances of personalized branding text (`Chloé`, bespoke phrases) with `NurseTools` and more neutral French messages in `App.tsx`, `Navigation.tsx`, `Home.tsx`, and `tabs/PatientNotes.tsx`.
- In `WeatherWidget.tsx` changed default city to `Paris`, added `OpenMeteo` geocoding + current weather fallback when `VITE_WEATHER_API_KEY` is not present, added `weatherCodeToFrenchLabel` mapping, and surface the location name in the widget.
- Improved weather fetch error handling and removed hard failure when no API key is set, keeping a single `Weather` shape for downstream code.
- Enhanced the notes block in `tabs/PatientNotes.tsx` by adding `removeNote` and `clearNotes` actions, a clear-all button, per-note delete buttons, and more robust list keys and UI layout.
- Updated the `AProposTab` subtitle and copy to remove personal dedication and emphasize clinical guidance.
- In `ui/UI.tsx` normalized the `Field` input value to present empty string when a numeric `value` is `NaN`, preventing uncontrolled/value errors in number fields.

### Testing
- Ran a TypeScript build (`npm run build`) to validate compilation and the front-end bundle, which completed successfully.
- Executed the test suite (`npm test`) and linters where available, and automated checks passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66c94f5bc83329badb1642af66c3a)