### PR TITLE
Introduce clinical tools, service presets and UI overhaul (icons, navigation, theme, weather)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "framer-motion": "^11.0.0",
+        "lucide-react": "^1.7.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2907,6 +2908,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {
@@ -6078,6 +6088,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "requires": {}
     },
     "merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "framer-motion": "^11.0.0",
+    "lucide-react": "^1.7.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,25 +117,6 @@ export default function NurseToolkitApp() {
     return null;
   };
 
-  const toolGrid = (
-    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-      {TOOLS.map((tool) => (
-        <button
-          key={tool.id}
-          type="button"
-          onClick={() => setActiveTool(tool.id)}
-          className="text-left rounded-2xl border border-border bg-card p-4 shadow-e2 hover:shadow-e4 transition focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-surface text-primary">
-            {tool.icon}
-          </div>
-          <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100 leading-tight">{tool.title}</h3>
-          <p className="mt-1 text-xs text-muted leading-snug">{tool.subtitle}</p>
-        </button>
-      ))}
-    </div>
-  );
-
   const filteredTools = useMemo(() => {
     const q = search.trim().toLowerCase();
     if (!q) return TOOLS;
@@ -182,31 +163,38 @@ export default function NurseToolkitApp() {
                 </section>
               ) : section === 'home' ? (
                 <section className="space-y-4 pb-24">
-                  <p className="text-sm text-muted">
-                    Accès rapide: touchez une carte pour ouvrir une vue isolée, sans défilement infini.
-                  </p>
-                  <div className="rounded-2xl border border-border bg-card p-4">
-                    <div className="text-xs uppercase tracking-wider text-muted">Mémo de garde</div>
-                    <div className="mt-1 text-sm text-slate-900 dark:text-slate-100">
-                      Vérifier identité patient, allergie, dose, voie, horaire.
+                  <div className="rounded-2xl border border-border bg-card p-5">
+                    <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Nurse&apos;s Toolbox</h2>
+                    <p className="text-sm text-muted mt-1">
+                      Navigation simple: sélectionnez une section principale depuis cette page.
+                    </p>
+                    <div className="mt-4 grid gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setSection('tools')}
+                        className="rounded-xl border border-border bg-surface px-4 py-3 text-left hover:bg-card"
+                      >
+                        <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">Ouvrir les outils cliniques</div>
+                        <div className="text-xs text-muted">Calcul de dose, perfusion, gazométrie, normes biologie…</div>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setSection('memos')}
+                        className="rounded-xl border border-border bg-surface px-4 py-3 text-left hover:bg-card"
+                      >
+                        <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">Ouvrir les mémos</div>
+                        <div className="text-xs text-muted">Notes rapides de garde.</div>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setSection('settings')}
+                        className="rounded-xl border border-border bg-surface px-4 py-3 text-left hover:bg-card"
+                      >
+                        <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">Configurer le protocole local</div>
+                        <div className="text-xs text-muted">Presets service injectés automatiquement dans les calculs.</div>
+                      </button>
                     </div>
                   </div>
-                  <div className="rounded-2xl border border-border bg-card p-4">
-                    <div className="text-xs uppercase tracking-wider text-muted mb-2">Outils récents</div>
-                    <div className="grid grid-cols-2 gap-2">
-                      {TOOLS.slice(0, 3).map((tool) => (
-                        <button
-                          key={`recent-${tool.id}`}
-                          type="button"
-                          onClick={() => setActiveTool(tool.id)}
-                          className="rounded-xl border border-border bg-surface px-3 py-2 text-left text-sm hover:bg-card"
-                        >
-                          {tool.title}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  {toolGrid}
                 </section>
               ) : section === 'tools' ? (
                 <section className="space-y-4 pb-24">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,75 +1,222 @@
-// File: src/App.tsx
-// Rôle: point d'entrée visuel, gestion d'état d'onglet, layout général (design modernisé et épuré)
-
-import { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Activity, Calculator, ClipboardList, FlaskConical, Settings2, UserRound } from 'lucide-react';
 import { Header, BottomNav } from './Navigation';
-import { Greeting, Tabs } from './Home';
-import { TabContent } from './TabsRouter';
-import { fadeInUp } from './ui/motion/presets';
+import { GazometrieTab } from './tabs/Gazometrie';
+import { PatientTab, NotesTab } from './tabs/PatientNotes';
 import { transition } from './ui/motion/transition';
+import { fadeInUp } from './ui/motion/presets';
 import { useReducedMotion } from './ui/motion/ReducedMotion';
-import { WeatherWidget, type Weather } from './WeatherWidget';
+import {
+  BiologyReferenceTool,
+  DoseTool,
+  PerfusionTool,
+} from './isolated/IsolatedTools';
+import { SERVICE_PRESETS, type ServicePreset, type ServicePresetId } from './isolated/presets';
 
+export type SectionKey = 'home' | 'tools' | 'memos' | 'settings';
 export type TabKey = 'calculs' | 'gaz' | 'patient' | 'notes' | 'apropos';
 
+type ToolId = 'dose' | 'perfusion' | 'gazometrie' | 'patient' | 'bio';
+
+type ToolMeta = {
+  id: ToolId;
+  title: string;
+  subtitle: string;
+  icon: ReactNode;
+  section: 'tools';
+};
+
+const TOOLS: ToolMeta[] = [
+  {
+    id: 'dose',
+    title: 'Calcul de dose',
+    subtitle: 'Dose → volume à prélever',
+    icon: <Calculator className="h-7 w-7" />,
+    section: 'tools',
+  },
+  {
+    id: 'perfusion',
+    title: 'Perfusion',
+    subtitle: 'mL/h, gtt/min, heure de fin',
+    icon: <ClipboardList className="h-7 w-7" />,
+    section: 'tools',
+  },
+  {
+    id: 'gazometrie',
+    title: 'Gazométrie',
+    subtitle: 'Interprétation ABG rapide',
+    icon: <Activity className="h-7 w-7" />,
+    section: 'tools',
+  },
+  {
+    id: 'patient',
+    title: 'Repères patient',
+    subtitle: 'CrCl, IMC',
+    icon: <UserRound className="h-7 w-7" />,
+    section: 'tools',
+  },
+  {
+    id: 'bio',
+    title: 'Normes biologie',
+    subtitle: 'Référence rapide isolée',
+    icon: <FlaskConical className="h-7 w-7" />,
+    section: 'tools',
+  },
+];
+
 export default function NurseToolkitApp() {
-  const [tab, setTab] = useState<TabKey>('gaz');
-  const [weather, setWeather] = useState<Weather | null>(null);
-  const [dark, setDark] = useState(false);
+  const [section, setSection] = useState<SectionKey>('home');
+  const [activeTool, setActiveTool] = useState<ToolId | null>(null);
+  const [serviceId, setServiceId] = useState<ServicePresetId>('polyvalent');
+  const [dark, setDark] = useState<boolean>(() => {
+    try {
+      const saved = localStorage.getItem('theme');
+      if (saved === 'dark') return true;
+      if (saved === 'light') return false;
+    } catch {
+      // ignore storage errors
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
 
   const prefersReduced = useReducedMotion();
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('theme', dark ? 'dark' : 'light');
+    } catch {
+      // ignore storage errors
+    }
+  }, [dark]);
+
+  const preset: ServicePreset = SERVICE_PRESETS[serviceId];
+
+  const currentTitle = useMemo(() => {
+    if (activeTool) return TOOLS.find((t) => t.id === activeTool)?.title ?? 'Outil';
+    if (section === 'home') return 'Accueil';
+    if (section === 'tools') return 'Outils';
+    if (section === 'memos') return 'Mémos';
+    return 'Réglages';
+  }, [section, activeTool]);
+
+  const renderTool = () => {
+    if (activeTool === 'dose') return <DoseTool preset={preset} />;
+    if (activeTool === 'perfusion') return <PerfusionTool preset={preset} />;
+    if (activeTool === 'gazometrie') return <GazometrieTab />;
+    if (activeTool === 'patient') return <PatientTab />;
+    if (activeTool === 'bio') return <BiologyReferenceTool />;
+    return null;
+  };
+
+  const toolGrid = (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {TOOLS.map((tool) => (
+        <button
+          key={tool.id}
+          type="button"
+          onClick={() => setActiveTool(tool.id)}
+          className="text-left rounded-2xl border border-border bg-card p-4 shadow-e2 hover:shadow-e4 transition focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-surface text-primary">
+            {tool.icon}
+          </div>
+          <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100 leading-tight">{tool.title}</h3>
+          <p className="mt-1 text-xs text-muted leading-snug">{tool.subtitle}</p>
+        </button>
+      ))}
+    </div>
+  );
 
   return (
     <div className={dark ? 'dark' : ''}>
       <div className="min-h-screen bg-background text-slate-900 dark:text-slate-100 font-sans">
         <Header
-          onChangeTab={setTab}
-          active={tab}
+          title={currentTitle}
           dark={dark}
           onToggleDark={() => setDark((d) => !d)}
+          onBack={activeTool ? () => setActiveTool(null) : undefined}
         />
 
-        <motion.main
-          className="mx-auto w-full max-w-3xl px-4 pb-28 sm:pb-24"
-          initial="hidden"
-          animate="visible"
-          variants={prefersReduced ? undefined : fadeInUp}
-          transition={transition}
-        >
-          <Greeting weather={weather} />
-          <WeatherWidget onWeather={setWeather} showSprout />
-          <Tabs active={tab} onChange={setTab} />
+        <main className="mx-auto w-full max-w-4xl px-4 pb-28 pt-4 sm:pt-6">
           <AnimatePresence mode="wait">
             <motion.div
-              key={tab}
-              className="mt-6"
+              key={activeTool ?? section}
               initial="hidden"
               animate="visible"
               exit="hidden"
               variants={prefersReduced ? undefined : fadeInUp}
               transition={transition}
             >
-              <div className="rounded-2xl bg-card shadow-e3 p-6 border border-border">
-                <TabContent active={tab} />
-              </div>
+              {activeTool ? (
+                <section className="rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6">
+                  {renderTool()}
+                </section>
+              ) : section === 'home' ? (
+                <section className="space-y-4">
+                  <p className="text-sm text-muted">
+                    Accès rapide: touchez une carte pour ouvrir une vue isolée, sans défilement infini.
+                  </p>
+                  {toolGrid}
+                </section>
+              ) : section === 'tools' ? (
+                <section className="space-y-4">
+                  <p className="text-sm text-muted">Choisissez un outil clinique dédié.</p>
+                  {toolGrid}
+                </section>
+              ) : section === 'memos' ? (
+                <section className="rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6">
+                  <NotesTab />
+                </section>
+              ) : (
+                <section className="space-y-4 rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6">
+                  <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Protocole local actif</h2>
+                  <p className="text-sm text-muted">
+                    Les presets service sont gérés ici et injectés automatiquement dans les outils Dose et Perfusion.
+                  </p>
+                  <label className="block">
+                    <div className="text-sm text-muted mb-1">Service</div>
+                    <select
+                      className="w-full rounded-md border border-border bg-surface px-3 py-2"
+                      value={serviceId}
+                      onChange={(e) => setServiceId(e.target.value as ServicePresetId)}
+                    >
+                      <option value="polyvalent">Polyvalent</option>
+                      <option value="urgences">Urgences</option>
+                      <option value="usi">USI / Réa</option>
+                      <option value="pediatrie">Pédiatrie</option>
+                    </select>
+                  </label>
+                  <div className="rounded-2xl border border-border bg-surface p-3">
+                    <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">{preset.label}</div>
+                    <div className="text-xs text-muted mt-1">Concentration par défaut: {preset.defaultConcentrationMgMl} mg/mL</div>
+                    <div className="text-xs text-muted">Facteur de chute: {preset.dripFactor} gtt/mL</div>
+                    <ul className="mt-2 space-y-1 text-xs text-muted">
+                      {preset.checks.map((c, i) => (
+                        <li key={i}>• {c}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="rounded-2xl border border-border bg-surface p-3 text-sm text-muted">
+                    <div className="font-semibold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+                      <Settings2 className="h-4 w-4" /> Sécurité
+                    </div>
+                    Les résultats restent une aide au calcul : toujours appliquer le protocole local et le double contrôle IDE.
+                  </div>
+                </section>
+              )}
             </motion.div>
           </AnimatePresence>
-        </motion.main>
+        </main>
 
-        <BottomNav active={tab} onChange={setTab} />
-
-        <footer className="mt-10 border-t border-border bg-surface/70 backdrop-blur-md">
-          <div className="mx-auto w-full max-w-3xl px-4 py-6 text-sm text-muted">
-            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-              <div>
-                ⚠️ Cet outil aide uniquement aux calculs infirmiers — il ne
-                remplace pas l'avis médical.
-              </div>
-              <div>© {new Date().getFullYear()} — Fait avec ❤️ pour Chloé</div>
-            </div>
-          </div>
-        </footer>
+        <BottomNav
+          active={section}
+          onChange={(next) => {
+            setSection(next);
+            setActiveTool(null);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ type ToolMeta = {
   subtitle: string;
   icon: ReactNode;
   section: 'tools';
+  category: 'Calculs' | 'Réanimation' | 'Scores';
 };
 
 const TOOLS: ToolMeta[] = [
@@ -35,6 +36,7 @@ const TOOLS: ToolMeta[] = [
     subtitle: 'Dose → volume à prélever',
     icon: <Calculator className="h-7 w-7" />,
     section: 'tools',
+    category: 'Calculs',
   },
   {
     id: 'perfusion',
@@ -42,6 +44,7 @@ const TOOLS: ToolMeta[] = [
     subtitle: 'mL/h, gtt/min, heure de fin',
     icon: <ClipboardList className="h-7 w-7" />,
     section: 'tools',
+    category: 'Calculs',
   },
   {
     id: 'gazometrie',
@@ -49,6 +52,7 @@ const TOOLS: ToolMeta[] = [
     subtitle: 'Interprétation ABG rapide',
     icon: <Activity className="h-7 w-7" />,
     section: 'tools',
+    category: 'Réanimation',
   },
   {
     id: 'patient',
@@ -56,6 +60,7 @@ const TOOLS: ToolMeta[] = [
     subtitle: 'CrCl, IMC',
     icon: <UserRound className="h-7 w-7" />,
     section: 'tools',
+    category: 'Scores',
   },
   {
     id: 'bio',
@@ -63,12 +68,14 @@ const TOOLS: ToolMeta[] = [
     subtitle: 'Référence rapide isolée',
     icon: <FlaskConical className="h-7 w-7" />,
     section: 'tools',
+    category: 'Scores',
   },
 ];
 
 export default function NurseToolkitApp() {
   const [section, setSection] = useState<SectionKey>('home');
   const [activeTool, setActiveTool] = useState<ToolId | null>(null);
+  const [search, setSearch] = useState('');
   const [serviceId, setServiceId] = useState<ServicePresetId>('polyvalent');
   const [dark, setDark] = useState<boolean>(() => {
     try {
@@ -129,6 +136,26 @@ export default function NurseToolkitApp() {
     </div>
   );
 
+  const filteredTools = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return TOOLS;
+    return TOOLS.filter(
+      (t) =>
+        t.title.toLowerCase().includes(q) ||
+        t.subtitle.toLowerCase().includes(q) ||
+        t.category.toLowerCase().includes(q)
+    );
+  }, [search]);
+
+  const toolsByCategory = useMemo(() => {
+    const groups: Record<string, ToolMeta[]> = {};
+    for (const t of filteredTools) {
+      if (!groups[t.category]) groups[t.category] = [];
+      groups[t.category].push(t);
+    }
+    return groups;
+  }, [filteredTools]);
+
   return (
     <div className={dark ? 'dark' : ''}>
       <div className="min-h-screen bg-background text-slate-900 dark:text-slate-100 font-sans">
@@ -150,27 +177,78 @@ export default function NurseToolkitApp() {
               transition={transition}
             >
               {activeTool ? (
-                <section className="rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6">
+                <section className="rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6 pb-24">
                   {renderTool()}
                 </section>
               ) : section === 'home' ? (
-                <section className="space-y-4">
+                <section className="space-y-4 pb-24">
                   <p className="text-sm text-muted">
                     Accès rapide: touchez une carte pour ouvrir une vue isolée, sans défilement infini.
                   </p>
+                  <div className="rounded-2xl border border-border bg-card p-4">
+                    <div className="text-xs uppercase tracking-wider text-muted">Mémo de garde</div>
+                    <div className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                      Vérifier identité patient, allergie, dose, voie, horaire.
+                    </div>
+                  </div>
+                  <div className="rounded-2xl border border-border bg-card p-4">
+                    <div className="text-xs uppercase tracking-wider text-muted mb-2">Outils récents</div>
+                    <div className="grid grid-cols-2 gap-2">
+                      {TOOLS.slice(0, 3).map((tool) => (
+                        <button
+                          key={`recent-${tool.id}`}
+                          type="button"
+                          onClick={() => setActiveTool(tool.id)}
+                          className="rounded-xl border border-border bg-surface px-3 py-2 text-left text-sm hover:bg-card"
+                        >
+                          {tool.title}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
                   {toolGrid}
                 </section>
               ) : section === 'tools' ? (
-                <section className="space-y-4">
-                  <p className="text-sm text-muted">Choisissez un outil clinique dédié.</p>
-                  {toolGrid}
+                <section className="space-y-4 pb-24">
+                  <p className="text-sm text-muted">Recherche rapide + outils groupés par catégorie.</p>
+                  <div className="rounded-2xl border border-border bg-card p-3">
+                    <input
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      placeholder="Rechercher un outil…"
+                      className="w-full rounded-xl border border-border bg-surface px-3 py-3 text-sm"
+                    />
+                  </div>
+                  {Object.entries(toolsByCategory).map(([category, list]) => (
+                    <section key={category} className="space-y-2">
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted">{category}</h3>
+                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                        {list.map((tool) => (
+                          <button
+                            key={tool.id}
+                            type="button"
+                            onClick={() => setActiveTool(tool.id)}
+                            className="text-left rounded-2xl border border-border bg-card p-4 shadow-e2 hover:shadow-e4 transition focus:outline-none focus:ring-2 focus:ring-ring"
+                          >
+                            <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-surface text-primary">
+                              {tool.icon}
+                            </div>
+                            <h4 className="text-base font-semibold text-slate-900 dark:text-slate-100 leading-tight">
+                              {tool.title}
+                            </h4>
+                            <p className="mt-1 text-xs text-muted leading-snug">{tool.subtitle}</p>
+                          </button>
+                        ))}
+                      </div>
+                    </section>
+                  ))}
                 </section>
               ) : section === 'memos' ? (
-                <section className="rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6">
+                <section className="rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6 pb-24">
                   <NotesTab />
                 </section>
               ) : (
-                <section className="space-y-4 rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6">
+                <section className="space-y-4 rounded-3xl border border-border bg-card shadow-e4 p-4 sm:p-6 pb-24">
                   <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Protocole local actif</h2>
                   <p className="text-sm text-muted">
                     Les presets service sont gérés ici et injectés automatiquement dans les outils Dose et Perfusion.

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -2,7 +2,10 @@
 // Header d’accueil sobre + barre d’onglets (utilise la météo passée par App)
 
 import { useMemo } from 'react';
-import type { TabKey } from './App';
+import type { ReactNode } from 'react';
+import { Activity, Calculator, Info, NotebookPen, UserRound } from 'lucide-react';
+
+type TabKey = 'calculs' | 'gaz' | 'patient' | 'notes' | 'apropos';
 
 type WeatherLite = { location: string; temp: number; condition: string } | null;
 
@@ -42,50 +45,45 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
 
   const dynamicTitle = useMemo(() => {
     if (cond.includes('tempête'))
-      return '🌪 Tempête dehors, sérénité dedans grâce à toi, ma héroïne.';
+      return '🌪 Vigilance météo : adaptez les transferts et déplacements.';
     if (cond.includes('grêle'))
-      return '🌨 Les grêlons tapent, mais tu gardes la réa au chaud.';
+      return '🌨 Conditions instables : anticipez les contraintes logistiques.';
     if (cond.includes('vent'))
-      return '💨 Vent fou, ton calme en réa ne vacille jamais, ma Chloé.';
+      return '💨 Vent soutenu : privilégiez une organisation simple et robuste.';
     if (cond.includes('bruine'))
-      return '🌦 Bruine légère, parfait pour un câlin avant la garde.';
+      return '🌦 Conditions humides : vérifiez confort et sécurité des trajets.';
     if (cond.includes('pluie'))
-      return '🌧 Un peu de pluie dehors, mais du soleil dans ton cœur.';
+      return '🌧 Journée pluvieuse : gardez des repères clairs et rapides.';
     if (cond.includes('neige'))
-      return '❄️ Temps parfait pour un chocolat chaud sous un plaid.';
+      return '❄️ Conditions hivernales : sécurisez les priorités de la garde.';
     if (cond.includes('orage'))
-      return '⛈ Calme dans la tempête, Chloé.';
+      return '⛈ Contexte orageux : maintenez un workflow calmement structuré.';
     if (cond.includes('brouillard'))
-      return '🌫 Horizon flou, mission claire.';
+      return '🌫 Visibilité réduite : privilégiez la clarté des transmissions.';
     if (cond.includes('nuage'))
-      return '🌤 Un temps doux pour adoucir la garde.';
+      return '🌤 Journée calme : appuyez-vous sur des outils fiables.';
     if (cond.includes('soleil') || cond.includes('ensoleillé'))
-      return '☀️ Un grand soleil pour éclairer ta journée, Chloé !';
+      return '☀️ Bonne journée pour avancer efficacement.';
     if (temp !== undefined) {
       if (temp >= 35)
-        return '🔥 Canicule en vue, pense à bien t’hydrater.';
+        return '🔥 Forte chaleur : pensez hydratation et pauses régulières.';
       if (temp >= 30)
-        return '🥵 Grosse chaleur, j’ai glissé une bouteille fraîche dans ton sac.';
+        return '🥵 Chaleur marquée : adaptez le rythme et l’hydratation.';
       if (temp >= 25)
-        return '🌡 Il fait chaud, courage pour la garde.';
+        return '🌡 Température élevée : gardez un rythme soutenable.';
       if (temp >= 15)
-        return '🌼 Douce température, ton sourire rassure toute la réa.';
+        return '🌼 Conditions agréables pour une garde sereine.';
       if (temp >= 10)
-        return '🍂 Petit air frais, je t’ai laissé un pull dans le casier.';
-      if (temp <= -5)
-        return '🧊 Froid mordant, tu restes la flamme des soins intensifs.';
+        return '🍂 Air frais : pensez à vous couvrir entre deux déplacements.';
+      if (temp <= -5) return '🧊 Froid intense : restez bien protégé.';
       if (temp <= 0)
-        return '🥶 Il fait glacial, couvre-toi bien !';
-      if (temp < 10)
-        return '🧥 Temps frais, garde ton gilet à portée.';
+        return '🥶 Température négative : prudence et équipement adapté.';
+      if (temp < 10) return '🧥 Temps frais : restez bien couvert.';
     }
-    if (h >= 21 || h < 6)
-      return '🌙 Douce nuit, prends soin de toi.';
-    if (h >= 6 && h < 9)
-      return '🌅 Bonjour ma star de la réa, ton café t’attend.';
-    if (h >= 18 && h < 21)
-      return '🌆 Fin de garde en vue, je t’attends avec un gros câlin.';
-    return '🌤 Un temps doux pour adoucir la garde.';
+    if (h >= 21 || h < 6) return '🌙 Service de nuit : gardez des checks simples.';
+    if (h >= 6 && h < 9) return '🌅 Démarrage de journée : focus sur l’essentiel.';
+    if (h >= 18 && h < 21) return '🌆 Fin de journée : sécurisez les transmissions.';
+    return '🌤 Outils rapides pour les routines de soins.';
   }, [cond, temp, h]);
 
   const dateStr = now.toLocaleDateString('fr-FR', {
@@ -107,14 +105,14 @@ export function Greeting({ weather }: { weather: WeatherLite }) {
       </div>
 
       {/* Titre sobre avec gradient léger */}
-      <h2 className="mt-2 text-3xl sm:text-4xl font-extrabold leading-tight font-display">
+      <h2 className="mt-2 text-3xl sm:text-4xl font-extrabold leading-tight tracking-tight">
         <span className="bg-gradient-to-r from-moss via-primary to-mint bg-clip-text text-transparent">
           {dynamicTitle}
         </span>
       </h2>
 
       {/* Sous-texte concis */}
-      <p className="mt-2 text-muted">
+      <p className="mt-2 text-muted text-sm sm:text-base">
         Calculs rapides, repères utiles et outils patients.
         <span className="hidden sm:inline">
           {' '}
@@ -133,25 +131,25 @@ export function Tabs({
   active: TabKey;
   onChange: (t: TabKey) => void;
 }) {
-  const items: { id: TabKey; label: string; icon: string }[] = [
-    { id: 'calculs', icon: '💊', label: 'Calculs' },
-    { id: 'gaz', icon: '🩸', label: 'Gazométrie' },
-    { id: 'patient', icon: '🧪', label: 'Patient' },
-    { id: 'notes', icon: '🗒️', label: 'Notes' },
-    { id: 'apropos', icon: 'ℹ️', label: 'À propos' },
+  const items: { id: TabKey; label: string; icon: ReactNode; domainClass: string }[] = [
+    { id: 'calculs', icon: <Calculator className="h-4 w-4" />, label: 'Calculs', domainClass: 'domain-calculs' },
+    { id: 'gaz', icon: <Activity className="h-4 w-4" />, label: 'Gazométrie', domainClass: 'domain-gaz' },
+    { id: 'patient', icon: <UserRound className="h-4 w-4" />, label: 'Patient', domainClass: 'domain-patient' },
+    { id: 'notes', icon: <NotebookPen className="h-4 w-4" />, label: 'Notes', domainClass: 'domain-notes' },
+    { id: 'apropos', icon: <Info className="h-4 w-4" />, label: 'À propos', domainClass: 'domain-apropos' },
   ];
 
-  const cls = (is: boolean) =>
+  const cls = (is: boolean, domainClass: string) =>
     [
       'group rounded-2xl border transition shadow-sm focus:outline-none focus:ring-2 focus:ring-ring',
-      'flex items-center justify-center gap-2 px-3 py-2 text-sm',
+      'flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium',
       is
-        ? 'bg-gradient-to-r from-primary to-mint text-primary-foreground border-transparent shadow-e2'
+        ? `${domainClass} text-slate-950 border-transparent shadow-e4`
         : 'bg-surface hover:bg-surface/80 text-muted border-border',
     ].join(' ');
 
   return (
-    <div className="mt-5 grid grid-cols-2 sm:grid-cols-5 gap-2" role="tablist">
+    <div className="mt-5 hidden sm:grid sm:grid-cols-5 gap-2" role="tablist">
       {items.map((t) => {
         const is = active === t.id;
         return (
@@ -160,12 +158,12 @@ export function Tabs({
             role="tab"
             aria-selected={is}
             onClick={() => onChange(t.id)}
-            className={cls(is)}
+            className={cls(is, t.domainClass)}
           >
             <span className="text-base leading-none" aria-hidden>
               {t.icon}
             </span>
-            <span className="font-medium">{t.label}</span>
+            <span>{t.label}</span>
             {is && (
               <span
                 className="ml-1 inline-flex h-1.5 w-1.5 rounded-full bg-white/80"
@@ -175,6 +173,31 @@ export function Tabs({
           </button>
         );
       })}
+    </div>
+  );
+}
+
+export function ColorGuide({ active }: { active: TabKey }) {
+  const items: { id: TabKey; label: string; cls: string }[] = [
+    { id: 'calculs', label: 'Calculs', cls: 'domain-calculs' },
+    { id: 'gaz', label: 'Gazométrie', cls: 'domain-gaz' },
+    { id: 'patient', label: 'Patient', cls: 'domain-patient' },
+    { id: 'notes', label: 'Notes', cls: 'domain-notes' },
+    { id: 'apropos', label: 'Info', cls: 'domain-apropos' },
+  ];
+
+  return (
+    <div className="mt-4 flex flex-wrap gap-2">
+      {items.map((i) => (
+        <span
+          key={i.id}
+          className={`rounded-full border px-3 py-1 text-[11px] font-medium tracking-wide ${
+            active === i.id ? `${i.cls} text-slate-950 border-transparent` : 'bg-surface border-border text-muted'
+          }`}
+        >
+          {i.label}
+        </span>
+      ))}
     </div>
   );
 }

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -64,8 +64,8 @@ export function BottomNav({
   ];
 
   return (
-    <nav className="fixed bottom-0 inset-x-0 z-40" aria-label="Navigation principale mobile">
-      <div className="mx-auto max-w-4xl bg-surface/95 backdrop-blur-xl border-t border-border shadow-e4">
+    <nav className="fixed bottom-0 inset-x-0 z-50" aria-label="Navigation principale mobile">
+      <div className="mx-auto max-w-4xl bg-surface border-t border-border shadow-e4">
         <div className="grid grid-cols-4 gap-1 px-2 py-2">
           {items.map((t) => {
             const is = active === t.id;

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,101 +1,51 @@
-// File: src/Navigation.tsx
-// Rôle: en-têtes et navigation (desktop + mobile)
-
-import type { TabKey } from './App';
-
-function Sun() {
-  return (
-    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <circle cx="12" cy="12" r="5" />
-      <path d="M12 1v2" />
-      <path d="M12 21v2" />
-      <path d="M4.22 4.22l1.42 1.42" />
-      <path d="M18.36 18.36l1.42 1.42" />
-      <path d="M1 12h2" />
-      <path d="M21 12h2" />
-      <path d="M4.22 19.78l1.42-1.42" />
-      <path d="M18.36 5.64l1.42-1.42" />
-    </svg>
-  );
-}
-
-function Moon() {
-  return (
-    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
-    </svg>
-  );
-}
+import { ArrowLeft, Grid2x2, Moon, NotebookPen, Settings, Sun, Wrench } from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { SectionKey } from './App';
 
 export function Header({
-  onChangeTab,
-  active,
+  title,
   dark,
   onToggleDark,
+  onBack,
 }: {
-  onChangeTab: (t: TabKey) => void;
-  active: TabKey;
+  title: string;
   dark: boolean;
   onToggleDark: () => void;
+  onBack?: () => void;
 }) {
   return (
-    <header className="sticky top-0 z-40 bg-surface/70 backdrop-blur-md shadow-e2 border-b border-border">
-      <div className="mx-auto w-full max-w-3xl px-4 py-3 flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight font-display">
-          <span className="inline-flex items-center gap-2">
-            <span className="inline-block h-6 w-6 rounded-xl bg-primary" aria-hidden />
-            <span>Outils de Chloé</span>
-          </span>
-        </h1>
-        <div className="flex items-center gap-2">
-          <nav
-            className="hidden sm:flex gap-2 text-sm"
-            aria-label="Navigation principale"
-          >
-            <TopLink id="calculs" label="Calculs" active={active} onClick={onChangeTab} />
-            <TopLink id="gaz" label="Gazométrie" active={active} onClick={onChangeTab} />
-            <TopLink id="patient" label="Patient" active={active} onClick={onChangeTab} />
-            <TopLink id="notes" label="Notes" active={active} onClick={onChangeTab} />
-            <TopLink id="apropos" label="À propos" active={active} onClick={onChangeTab} />
-          </nav>
-          <button
-            onClick={onToggleDark}
-            aria-label="Changer de thème"
-            className="p-2 rounded-full hover:bg-surface focus:outline-none focus:ring-2 focus:ring-ring"
-            aria-pressed={dark}
-          >
-            {dark ? <Sun /> : <Moon />}
-          </button>
+    <header className="sticky top-0 z-40 border-b border-border bg-surface/92 backdrop-blur-xl">
+      <div className="mx-auto w-full max-w-4xl px-4 py-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          {onBack ? (
+            <button
+              type="button"
+              onClick={onBack}
+              aria-label="Retour"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-card text-muted hover:text-slate-900 dark:hover:text-slate-100"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+          ) : (
+            <div className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-card text-primary">
+              <Grid2x2 className="h-4 w-4" />
+            </div>
+          )}
+          <h1 className="truncate text-lg sm:text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+            {title}
+          </h1>
         </div>
+
+        <button
+          onClick={onToggleDark}
+          aria-label="Changer de thème"
+          className="p-2.5 rounded-full border border-border bg-card hover:bg-surface focus:outline-none focus:ring-2 focus:ring-ring transition"
+          aria-pressed={dark}
+        >
+          {dark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+        </button>
       </div>
     </header>
-  );
-}
-
-export function TopLink({
-  id,
-  label,
-  active,
-  onClick,
-}: {
-  id: TabKey;
-  label: string;
-  active: TabKey;
-  onClick: (t: TabKey) => void;
-}) {
-  const is = active === id;
-  return (
-    <button
-      onClick={() => onClick(id)}
-      className={`px-3 py-1.5 rounded-full border transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-ring hover:scale-105 active:scale-95 ${
-        is
-          ? 'bg-gradient-to-r from-primary to-mint text-primary-foreground border-transparent shadow-e2'
-          : 'bg-surface hover:bg-surface/80 text-muted border-border'
-      }`}
-      aria-current={is ? 'page' : undefined}
-    >
-      {label}
-    </button>
   );
 }
 
@@ -103,38 +53,35 @@ export function BottomNav({
   active,
   onChange,
 }: {
-  active: TabKey;
-  onChange: (t: TabKey) => void;
+  active: SectionKey;
+  onChange: (t: SectionKey) => void;
 }) {
-  const items: { id: TabKey; icon: string; label: string }[] = [
-    { id: 'calculs', icon: '💊', label: 'Calculs' },
-    { id: 'gaz', icon: '🩸', label: 'Gaz' },
-    { id: 'patient', icon: '🧪', label: 'Patient' },
-    { id: 'notes', icon: '🗒️', label: 'Notes' },
-    { id: 'apropos', icon: 'ℹ️', label: 'Infos' },
+  const items: { id: SectionKey; icon: ReactNode; label: string }[] = [
+    { id: 'home', icon: <Grid2x2 className="h-4 w-4" />, label: 'Accueil' },
+    { id: 'tools', icon: <Wrench className="h-4 w-4" />, label: 'Outils' },
+    { id: 'memos', icon: <NotebookPen className="h-4 w-4" />, label: 'Mémos' },
+    { id: 'settings', icon: <Settings className="h-4 w-4" />, label: 'Réglages' },
   ];
+
   return (
-    <nav
-      className="fixed bottom-0 inset-x-0 z-40 sm:hidden"
-      aria-label="Navigation mobile"
-    >
-      <div className="mx-auto max-w-3xl bg-surface/70 backdrop-blur-md border-t border-border shadow-e2">
-        <div className="grid grid-cols-5">
+    <nav className="fixed bottom-0 inset-x-0 z-40" aria-label="Navigation principale mobile">
+      <div className="mx-auto max-w-4xl bg-surface/95 backdrop-blur-xl border-t border-border shadow-e4">
+        <div className="grid grid-cols-4 gap-1 px-2 py-2">
           {items.map((t) => {
             const is = active === t.id;
             return (
               <button
                 key={t.id}
                 onClick={() => onChange(t.id)}
-                className={`flex flex-col items-center justify-center py-2 text-xs transform-gpu transition-transform duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-ring hover:scale-105 active:scale-95 ${
-                  is ? 'text-primary' : 'text-muted'
+                className={`flex flex-col items-center justify-center rounded-xl py-2 text-[11px] transition duration-200 focus:outline-none focus:ring-2 focus:ring-ring ${
+                  is ? 'bg-card text-primary shadow-e2' : 'text-muted hover:bg-card/80'
                 }`}
                 aria-current={is ? 'page' : undefined}
               >
                 <span className="text-base leading-none" aria-hidden>
                   {t.icon}
                 </span>
-                <span>{t.label}</span>
+                <span className="mt-1">{t.label}</span>
               </button>
             );
           })}

--- a/src/WeatherWidget.tsx
+++ b/src/WeatherWidget.tsx
@@ -71,17 +71,18 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout 
   const prefersReduced = useReducedMotion();
 
   useEffect(() => {
+    const controller = new AbortController();
     async function load() {
       const key = import.meta.env.VITE_WEATHER_API_KEY;
       if (!key) {
-        setError('Clé API manquante');
+        setError('Météo non configurée');
         onWeather?.(null);
         setLoading(false);
         return;
       }
       try {
         const url = `https://api.weatherapi.com/v1/current.json?key=${key}&q=${encodeURIComponent(city)}&lang=fr&aqi=no`;
-        const res = await fetch(url);
+        const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error('Erreur réseau');
         const json = await res.json();
         const w: Weather = {
@@ -93,6 +94,7 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout 
         onWeather?.(w);
         setError(null);
       } catch (e) {
+        if ((e as { name?: string })?.name === 'AbortError') return;
         console.error(e);
         setError('Météo indisponible');
         onWeather?.(null);
@@ -101,43 +103,34 @@ export function WeatherWidget({ city = 'Solliès-Toucas', onWeather, showSprout 
       }
     }
     load();
+    return () => controller.abort();
   }, [city, onWeather]);
 
   if (loading) {
     return (
       <div
-        className={`mt-4 h-24 w-full rounded-2xl bg-card border border-border ${prefersReduced ? '' : 'animate-pulse'}`}
+        className={`mt-3 h-10 w-full rounded-xl bg-card border border-border ${prefersReduced ? '' : 'animate-pulse'}`}
         aria-hidden
       />
     );
   }
 
   if (error || !data) {
-    return (
-      <div className="mt-4 text-sm text-muted" role="status">
-        {error || 'Météo indisponible'}
-      </div>
-    );
+    return null;
   }
 
   const cond = data.condition.toLowerCase();
   const mood = cond.includes('pluie') ? 'rainy' : 'happy';
-  const message = cond.includes('pluie')
-    ? 'La nature boit la pluie.'
-    : 'Belle journée verdoyante.';
-
   return (
-    <div className="mt-4 flex items-center justify-between rounded-2xl bg-card p-4 shadow-e2 border border-border">
-      <div className="flex items-center gap-3">
-        <span aria-hidden className="text-4xl">
+    <div className="mt-3 flex items-center justify-between rounded-xl border border-border bg-surface/70 px-3 py-2 text-sm text-muted">
+      <div className="flex min-w-0 items-center gap-2">
+        <span aria-hidden className="text-base">
           {iconFor(data.condition)}
         </span>
-        <div>
-          <div className="text-2xl font-bold text-primary">
-            {Math.round(data.temp)}°C
-          </div>
-          <div className="text-sm text-muted">{data.condition}</div>
-          <div className="text-xs text-muted/80">{message}</div>
+        <div className="truncate">
+          <span className="font-semibold text-primary">{Math.round(data.temp)}°C</span>
+          <span className="mx-2 opacity-40">•</span>
+          <span className="truncate">{data.condition}</span>
         </div>
       </div>
       {showSprout && <span className="ml-2"><Sprout mood={mood} /></span>}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -18,51 +20,62 @@ body {
 }
 
 :root {
-  --color-bg: #f6f9f7;
+  --color-bg: #f3f4f7;
   --color-surface: #ffffff;
-  --color-card: #f0f5f2;
-  --color-primary: #166534;
+  --color-card: #f7f8fb;
+  --color-primary: #4f46e5;
   --color-primary-fg: #ffffff;
   --color-muted: #6b7280;
-  --color-border: #d1d5db;
-  --color-ring: #16a34a;
+  --color-border: #d8dbe6;
+  --color-ring: #6366f1;
   --color-success: #16a34a;
   --color-warn: #ca8a04;
   --color-danger: #dc2626;
   --color-info: #0ea5e9;
-  --color-mint: #a7f3d0;
-  --color-moss: #4d7c0f;
+  --color-mint: #67e8f9;
+  --color-moss: #34d399;
+
+  --domain-calculs: #f5e84a;
+  --domain-gaz: #5ed8ff;
+  --domain-patient: #7ea2ff;
+  --domain-notes: #f472b6;
+  --domain-apropos: #4ade80;
 }
 
 .dark {
-  --color-bg: #0d1b14;
-  --color-surface: #16281d;
-  --color-card: #1d3425;
-  --color-primary: #4ade80;
-  --color-primary-fg: #0d1b14;
-  --color-muted: #9ca3af;
-  --color-border: #2e4b35;
-  --color-ring: #34d399;
-  --color-success: #22c55e;
-  --color-warn: #eab308;
-  --color-danger: #f87171;
+  --color-bg: #0a0b10;
+  --color-surface: #11141b;
+  --color-card: #0f1218;
+  --color-primary: #67e8f9;
+  --color-primary-fg: #0b1220;
+  --color-muted: #a8b0c2;
+  --color-border: #222734;
+  --color-ring: #7dd3fc;
+  --color-success: #4ade80;
+  --color-warn: #facc15;
+  --color-danger: #fb7185;
   --color-info: #38bdf8;
-  --color-mint: #34d399;
-  --color-moss: #a3e635;
+  --color-mint: #67e8f9;
+  --color-moss: #4ade80;
 }
 
 body {
   background-color: var(--color-bg);
   color: var(--color-muted);
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
 }
 
 body::before {
   content: "";
   position: fixed;
   inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath d='M0 0h40v40H0z' fill='%23000000' fill-opacity='0.02'/%3E%3C/svg%3E");
-  background-size: 160px 160px;
-  opacity: 0.03;
+  background-image:
+    radial-gradient(circle at 18% 10%, rgba(94, 216, 255, 0.14), transparent 30%),
+    radial-gradient(circle at 78% 14%, rgba(244, 114, 182, 0.12), transparent 28%),
+    radial-gradient(circle at 58% 86%, rgba(74, 222, 128, 0.1), transparent 30%);
+  opacity: 0.85;
   pointer-events: none;
   z-index: -1;
 }
@@ -75,6 +88,58 @@ body::before {
 
 #root {
   min-height: 100vh;
+}
+
+h1,
+h2,
+h3 {
+  font-family: 'Plus Jakarta Sans', 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.domain-calculs {
+  background: var(--domain-calculs);
+}
+
+.domain-gaz {
+  background: var(--domain-gaz);
+}
+
+.domain-patient {
+  background: var(--domain-patient);
+}
+
+.domain-notes {
+  background: var(--domain-notes);
+}
+
+.domain-apropos {
+  background: var(--domain-apropos);
+}
+
+.domain-frame-calculs {
+  border-color: rgba(245, 232, 74, 0.55);
+  box-shadow: 0 0 0 1px rgba(245, 232, 74, 0.18), 0 0 20px rgba(245, 232, 74, 0.08);
+}
+
+.domain-frame-gaz {
+  border-color: rgba(94, 216, 255, 0.55);
+  box-shadow: 0 0 0 1px rgba(94, 216, 255, 0.18), 0 0 20px rgba(94, 216, 255, 0.08);
+}
+
+.domain-frame-patient {
+  border-color: rgba(126, 162, 255, 0.55);
+  box-shadow: 0 0 0 1px rgba(126, 162, 255, 0.18), 0 0 20px rgba(126, 162, 255, 0.08);
+}
+
+.domain-frame-notes {
+  border-color: rgba(244, 114, 182, 0.55);
+  box-shadow: 0 0 0 1px rgba(244, 114, 182, 0.18), 0 0 20px rgba(244, 114, 182, 0.08);
+}
+
+.domain-frame-apropos {
+  border-color: rgba(74, 222, 128, 0.55);
+  box-shadow: 0 0 0 1px rgba(74, 222, 128, 0.18), 0 0 20px rgba(74, 222, 128, 0.08);
 }
 
 /* Styles pour les éléments de formulaire */

--- a/src/isolated/IsolatedTools.tsx
+++ b/src/isolated/IsolatedTools.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Card, Field, Result } from '../ui/UI';
+import { round, safeDiv } from '../utils';
+import type { ServicePreset } from './presets';
+
+export function DoseTool({ preset }: { preset: ServicePreset }) {
+  const [weight, setWeight] = useState<number>(70);
+  const [doseMgKg, setDoseMgKg] = useState<number>(1);
+  const [concentration, setConcentration] = useState<number>(preset.defaultConcentrationMgMl);
+
+  useEffect(() => {
+    setConcentration(preset.defaultConcentrationMgMl);
+  }, [preset.defaultConcentrationMgMl]);
+
+  const totalDose = useMemo(() => round(weight * doseMgKg), [weight, doseMgKg]);
+  const volumeMl = useMemo(() => round(safeDiv(totalDose, concentration)), [totalDose, concentration]);
+  const invalid = weight <= 0 || doseMgKg < 0 || concentration <= 0;
+
+  return (
+    <section className="space-y-4">
+      <Card title="Entrées patient" subtitle="Saisissez uniquement les paramètres nécessaires">
+        <Field label="Poids" value={weight} onChange={(v) => setWeight(Number(v))} suffix="kg" min={0} />
+        <Field
+          label="Dose prescrite"
+          value={doseMgKg}
+          onChange={(v) => setDoseMgKg(Number(v))}
+          suffix="mg/kg"
+          min={0}
+          step="0.1"
+        />
+        <Field
+          label="Concentration"
+          value={concentration}
+          onChange={(v) => setConcentration(Number(v))}
+          suffix="mg/mL"
+          min={0}
+          step="0.1"
+        />
+      </Card>
+
+      <Card title="Résultat" subtitle="Lecture immédiate avant administration">
+        <Result tone={invalid ? 'danger' : 'success'}>
+          <div className="text-2xl sm:text-4xl">{invalid ? 'Entrée invalide' : `${volumeMl} mL à prélever`}</div>
+          {!invalid && <div className="text-sm mt-1 opacity-80">Dose totale: {totalDose} mg</div>}
+        </Result>
+      </Card>
+    </section>
+  );
+}
+
+export function PerfusionTool({ preset }: { preset: ServicePreset }) {
+  const [volume, setVolume] = useState<number>(500);
+  const [hours, setHours] = useState<number>(2);
+  const [minutes, setMinutes] = useState<number>(0);
+  const [startTime, setStartTime] = useState<string>('08:00');
+  const [dripFactor, setDripFactor] = useState<number>(preset.dripFactor);
+
+  useEffect(() => {
+    setDripFactor(preset.dripFactor);
+  }, [preset.dripFactor]);
+
+  const totalHours = useMemo(() => hours + minutes / 60, [hours, minutes]);
+  const mlh = useMemo(() => round(safeDiv(volume, totalHours)), [volume, totalHours]);
+  const gttMin = useMemo(() => Math.round(safeDiv(volume * dripFactor, hours * 60 + minutes)), [volume, dripFactor, hours, minutes]);
+
+  const endTime = useMemo(() => {
+    const [h, m] = startTime.split(':').map(Number);
+    if (!Number.isFinite(h) || !Number.isFinite(m)) return '—';
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    d.setMinutes(d.getMinutes() + hours * 60 + minutes);
+    return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  }, [startTime, hours, minutes]);
+
+  const invalid = volume <= 0 || totalHours <= 0;
+
+  return (
+    <section className="space-y-4">
+      <Card title="Entrées perfusion" subtitle="Paramètres opérationnels">
+        <Field label="Volume" value={volume} onChange={(v) => setVolume(Number(v))} suffix="mL" min={0} />
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Heures" value={hours} onChange={(v) => setHours(Number(v))} suffix="h" min={0} />
+          <Field label="Minutes" value={minutes} onChange={(v) => setMinutes(Number(v))} suffix="min" min={0} />
+        </div>
+        <Field
+          label="Facteur de chute"
+          value={dripFactor}
+          onChange={(v) => setDripFactor(Number(v))}
+          suffix="gtt/mL"
+          min={0}
+        />
+        <label className="block mb-3">
+          <div className="text-sm text-muted mb-1">Heure de début</div>
+          <input
+            type="time"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            className="w-full rounded-md border border-border bg-surface px-3 py-2"
+          />
+        </label>
+      </Card>
+
+      <Card title="Résultat" subtitle="Double lecture avant branchement">
+        <Result tone={invalid ? 'danger' : 'info'}>
+          <div className="text-2xl sm:text-4xl">{invalid ? 'Entrée invalide' : `${mlh} mL/h`}</div>
+          {!invalid && (
+            <div className="text-sm mt-1 opacity-90">
+              {gttMin} gtt/min • Fin estimée: {endTime}
+            </div>
+          )}
+        </Result>
+      </Card>
+    </section>
+  );
+}
+
+export function BiologyReferenceTool() {
+  const items = [
+    ['pH artériel', '7.35 – 7.45'],
+    ['PaCO₂', '35 – 45 mmHg'],
+    ['HCO₃⁻', '22 – 26 mEq/L'],
+    ['Lactate', '≤ 2 mmol/L'],
+    ['Na⁺', '135 – 145 mmol/L'],
+    ['K⁺', '3.5 – 5.0 mmol/L'],
+    ['Créatinine', '≈ 45 – 105 µmol/L'],
+  ];
+
+  return (
+    <Card title="Normes biologie" subtitle="Référence rapide isolée">
+      <div className="grid sm:grid-cols-2 gap-2">
+        {items.map(([k, v]) => (
+          <div key={k} className="rounded-xl border border-border bg-surface px-3 py-2">
+            <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">{k}</div>
+            <div className="text-xs text-muted">{v}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/isolated/presets.ts
+++ b/src/isolated/presets.ts
@@ -1,0 +1,40 @@
+export type ServicePresetId = 'polyvalent' | 'urgences' | 'usi' | 'pediatrie';
+
+export type ServicePreset = {
+  id: ServicePresetId;
+  label: string;
+  defaultConcentrationMgMl: number;
+  dripFactor: number;
+  checks: string[];
+};
+
+export const SERVICE_PRESETS: Record<ServicePresetId, ServicePreset> = {
+  polyvalent: {
+    id: 'polyvalent',
+    label: 'Polyvalent',
+    defaultConcentrationMgMl: 10,
+    dripFactor: 20,
+    checks: ['Vérifier poids patient', 'Double contrôle dose/unité'],
+  },
+  urgences: {
+    id: 'urgences',
+    label: 'Urgences',
+    defaultConcentrationMgMl: 5,
+    dripFactor: 20,
+    checks: ['Priorité à la lisibilité du résultat', "Tracer heure de préparation"],
+  },
+  usi: {
+    id: 'usi',
+    label: 'USI / Réa',
+    defaultConcentrationMgMl: 4,
+    dripFactor: 60,
+    checks: ['Double contrôle IDE/IDE', 'Vérifier pousse-seringue et concentration'],
+  },
+  pediatrie: {
+    id: 'pediatrie',
+    label: 'Pédiatrie',
+    defaultConcentrationMgMl: 1,
+    dripFactor: 60,
+    checks: ['Poids actualisé du jour obligatoire', 'Re-vérifier dose maximale'],
+  },
+};

--- a/src/tabs/Calculs.tsx
+++ b/src/tabs/Calculs.tsx
@@ -5,16 +5,124 @@ import { useMemo, useState } from "react";
 import { Card, Field, Result } from "../ui/UI";
 import { safeDiv, round, toNum } from "../utils";
 
+type ServiceId = "polyvalent" | "urgences" | "usi" | "grandsBrules" | "pediatrie";
+
+type ServicePreset = {
+  label: string;
+  standardConcentrationMgMl: number;
+  regleTroisReferenceMgMl: number;
+  doubleCheckRules: string[];
+  tools: string[];
+};
+
+const SERVICE_PRESETS: Record<ServiceId, ServicePreset> = {
+  polyvalent: {
+    label: "Service polyvalent",
+    standardConcentrationMgMl: 10,
+    regleTroisReferenceMgMl: 250,
+    doubleCheckRules: [
+      "Double contrôle dose et unité (mg vs µg).",
+      "Vérifier poids de référence et fonction rénale.",
+    ],
+    tools: ["Dose mg/kg", "Débit perfusion", "Gouttes/min"],
+  },
+  urgences: {
+    label: "Urgences",
+    standardConcentrationMgMl: 5,
+    regleTroisReferenceMgMl: 100,
+    doubleCheckRules: [
+      "Tracer heure de préparation et heure d'administration.",
+      "Double contrôle obligatoire pour bolus/vasopresseurs.",
+    ],
+    tools: ["Bolus rapide mL/kg", "Shock index", "Règle de trois"],
+  },
+  usi: {
+    label: "USI / Réanimation",
+    standardConcentrationMgMl: 4,
+    regleTroisReferenceMgMl: 40,
+    doubleCheckRules: [
+      "Toujours valider concentration seringue sur pousse-seringue.",
+      "Double contrôle IDE/IDE pour catécholamines et sédation.",
+    ],
+    tools: ["Débit mL/h", "Dose µg/kg/min → mL/h", "Gazométrie"],
+  },
+  grandsBrules: {
+    label: "Unité grands brûlés",
+    standardConcentrationMgMl: 2,
+    regleTroisReferenceMgMl: 50,
+    doubleCheckRules: [
+      "Recalculer la surface brûlée (%) à chaque réévaluation.",
+      "Tracer bilan entrée/sortie et objectifs de diurèse.",
+    ],
+    tools: ["Parkland 24h", "Surface brûlée (règle des 9)", "Débit perfusion"],
+  },
+  pediatrie: {
+    label: "Pédiatrie",
+    standardConcentrationMgMl: 1,
+    regleTroisReferenceMgMl: 10,
+    doubleCheckRules: [
+      "Toujours calculer sur poids actualisé du jour.",
+      "Double contrôle systématique avant administration IV.",
+    ],
+    tools: ["Dose mg/kg", "Bolus mL/kg", "Limites max pédiatriques"],
+  },
+};
+
 export function CalculsTab() {
+  const [service, setService] = useState<ServiceId>("polyvalent");
+
   return (
     <section className="mt-6 space-y-6">
+      <ServiceSelector service={service} onServiceChange={setService} />
       <QuickPanel />
-      <DoseCalculator />
+      <DoseCalculator service={service} />
       <div className="grid sm:grid-cols-2 gap-6">
         <InfusionRate />
         <DripRate />
       </div>
+      <BiologyNorms />
+      <ServiceTools service={service} />
     </section>
+  );
+}
+
+function ServiceSelector({
+  service,
+  onServiceChange,
+}: {
+  service: ServiceId;
+  onServiceChange: (service: ServiceId) => void;
+}) {
+  const preset = SERVICE_PRESETS[service];
+  return (
+    <Card
+      title="Protocole local / presets service"
+      subtitle="Sélectionnez un service pour charger des repères de concentration et de double contrôle"
+    >
+      <label className="text-sm text-muted">
+        Service clinique
+        <select
+          className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          value={service}
+          onChange={(e) => onServiceChange(e.target.value as ServiceId)}
+        >
+          <option value="polyvalent">Polyvalent</option>
+          <option value="urgences">Urgences</option>
+          <option value="usi">USI / Réanimation</option>
+          <option value="grandsBrules">Grands brûlés</option>
+          <option value="pediatrie">Pédiatrie</option>
+        </select>
+      </label>
+      <div className="mt-2 text-xs text-muted">
+        Profil actif: <b>{preset.label}</b>
+      </div>
+      <div className="mt-2 text-xs text-muted">Outils fréquents: {preset.tools.join(" • ")}</div>
+      <ul className="mt-2 space-y-1 text-xs text-muted">
+        {preset.doubleCheckRules.map((rule, i) => (
+          <li key={i}>• {rule}</li>
+        ))}
+      </ul>
+    </Card>
   );
 }
 
@@ -23,6 +131,7 @@ function QuickPanel() {
   const [d, setD] = useState<number>(1);
   const [c, setC] = useState<number>(10);
   const ml = safeDiv(Number(w) * Number(d), Number(c));
+  const hasInvalidValues = w <= 0 || d < 0 || c <= 0;
   return (
     <div className="rounded-2xl border border-border bg-card p-4">
       <div className="text-sm font-medium mb-2">Raccourci: dose mg/kg → mL</div>
@@ -36,13 +145,20 @@ function QuickPanel() {
           onChange={(v) => setC(Number(v))}
         />
       </div>
-      <div className="rounded-xl border border-border bg-surface px-3 py-2 text-sm text-muted">≈ {round(ml)} mL</div>
+      <div className="rounded-xl border border-border bg-surface px-3 py-2 text-sm text-muted">
+        ≈ {round(ml)} mL
+      </div>
+      {hasInvalidValues && (
+        <div className="mt-2 text-xs text-danger">
+          Vérifiez les entrées: poids et concentration doivent être {'>'} 0, dose ≥ 0.
+        </div>
+      )}
     </div>
   );
 }
 
 type DoseMode = "mgkg" | "regle3" | "dilution";
-function DoseCalculator() {
+function DoseCalculator({ service }: { service: ServiceId }) {
   const [mode, setMode] = useState<DoseMode>("mgkg");
   const [poids, setPoids] = useState<number>(70);
   const [doseMgKg, setDoseMgKg] = useState<number>(1);
@@ -52,26 +168,184 @@ function DoseCalculator() {
   const [contenuAmpoule, setContenuAmpoule] = useState<number>(1000);
   const [volumeAmpoule, setVolumeAmpoule] = useState<number>(10);
   const [doseSouhaitee, setDoseSouhaitee] = useState<number>(250);
+  const [age, setAge] = useState<number>(65);
+  const [poidsRef, setPoidsRef] = useState<"reel" | "ideal" | "ajuste">("reel");
+  const [renal, setRenal] = useState<"normal" | "renale" | "dialyse">("normal");
+  const [grossesse, setGrossesse] = useState<"non" | "oui">("non");
+
+  const selectedPreset = SERVICE_PRESETS[service];
+
+  const applyServicePreset = () => {
+    setConcentration(selectedPreset.standardConcentrationMgMl);
+    setDispo(selectedPreset.regleTroisReferenceMgMl);
+  };
+
+  const safetyAlerts = useMemo(() => {
+    const alerts: string[] = [];
+    if (mode === "mgkg") {
+      if (poids <= 0) alerts.push("Poids patient invalide (doit être > 0 kg).");
+      if (doseMgKg < 0) alerts.push("Dose mg/kg négative non autorisée.");
+      if (concentration <= 0) alerts.push("Concentration invalide (doit être > 0 mg/mL).");
+      if (doseMgKg > 50) alerts.push("Dose mg/kg élevée: vérifier l'unité et la prescription.");
+      if (concentration > 1000) alerts.push("Concentration très élevée: confirmer la dilution.");
+      if (service === "pediatrie" && doseMgKg > 10)
+        alerts.push("Pédiatrie: dose mg/kg élevée, vérifier la dose maximale autorisée.");
+    }
+    if (mode === "regle3") {
+      if (voulu < 0) alerts.push("Dose voulue négative non autorisée.");
+      if (dispo <= 0) alerts.push("Concentration disponible invalide (doit être > 0).");
+    }
+    if (mode === "dilution") {
+      if (contenuAmpoule <= 0) alerts.push("Contenu ampoule invalide (doit être > 0).");
+      if (volumeAmpoule <= 0) alerts.push("Volume ampoule invalide (doit être > 0 mL).");
+      if (doseSouhaitee < 0) alerts.push("Dose souhaitée négative non autorisée.");
+      if (doseSouhaitee > contenuAmpoule)
+        alerts.push("Dose souhaitée > contenu ampoule: dilution/reconstitution à confirmer.");
+    }
+
+    if (age >= 75) alerts.push("Patient âgé: démarrer bas et recontrôler la tolérance.");
+    if (renal !== "normal")
+      alerts.push("Contexte rénal à risque: adapter la posologie selon protocole local.");
+    if (grossesse === "oui")
+      alerts.push("Grossesse déclarée: vérifier les contre-indications spécifiques.");
+    if (poidsRef !== "reel")
+      alerts.push("Poids de référence non réel: valider la formule de dose choisie.");
+    if (service === "grandsBrules")
+      alerts.push("Grands brûlés: réévaluer fréquemment les besoins hydriques.");
+
+    return alerts;
+  }, [
+    mode,
+    poids,
+    doseMgKg,
+    concentration,
+    voulu,
+    dispo,
+    contenuAmpoule,
+    volumeAmpoule,
+    doseSouhaitee,
+    age,
+    renal,
+    grossesse,
+    poidsRef,
+    service,
+  ]);
+
+  const hardStop = useMemo(() => {
+    if (mode === "mgkg") return poids <= 0 || doseMgKg < 0 || concentration <= 0;
+    if (mode === "regle3") return voulu < 0 || dispo <= 0;
+    if (mode === "dilution")
+      return contenuAmpoule <= 0 || volumeAmpoule <= 0 || doseSouhaitee < 0;
+    return false;
+  }, [
+    mode,
+    poids,
+    doseMgKg,
+    concentration,
+    voulu,
+    dispo,
+    contenuAmpoule,
+    volumeAmpoule,
+    doseSouhaitee,
+  ]);
 
   const res = useMemo(() => {
+    if (hardStop) {
+      return {
+        text: "Entrée invalide: corrigez les champs en erreur avant validation.",
+        tone: "danger" as const,
+      };
+    }
     if (mode === "mgkg") {
       const doseTotaleMg = Number(poids) * Number(doseMgKg);
       const ml = safeDiv(doseTotaleMg, Number(concentration));
-      return { text: `${round(doseTotaleMg)} mg au total → ${round(ml)} mL à prélever.`, tone: "ok" as const };
+      return {
+        text: `${round(doseTotaleMg)} mg au total → ${round(ml)} mL à prélever.`,
+        tone: "success" as const,
+      };
     }
     if (mode === "regle3") {
       const ml = safeDiv(Number(voulu), Number(dispo));
-      return { text: `${round(ml)} mL à prélever.`, tone: "ok" as const };
+      return { text: `${round(ml)} mL à prélever.`, tone: "success" as const };
     }
     if (mode === "dilution") {
       const v1 = safeDiv(Number(doseSouhaitee), Number(contenuAmpoule)) * Number(volumeAmpoule);
-      return { text: `${round(v1)} mL à prélever depuis l'ampoule. Compléter avec solvant selon protocole.`, tone: "info" as const };
+      return {
+        text: `${round(v1)} mL à prélever depuis l'ampoule. Compléter avec solvant selon protocole.`,
+        tone: "info" as const,
+      };
     }
     return { text: "", tone: "info" as const };
-  }, [mode, poids, doseMgKg, concentration, voulu, dispo, contenuAmpoule, volumeAmpoule, doseSouhaitee]);
+  }, [
+    mode,
+    poids,
+    doseMgKg,
+    concentration,
+    voulu,
+    dispo,
+    contenuAmpoule,
+    volumeAmpoule,
+    doseSouhaitee,
+    hardStop,
+  ]);
 
   return (
     <Card title="Calcul de dose" subtitle="Règle de trois, mg/kg, dilution">
+      <div className="mb-3 rounded-xl border border-border bg-surface p-3">
+        <div className="text-xs font-medium text-muted mb-2">Preset appliqué au calcul</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="text-xs text-muted">{selectedPreset.label}</div>
+          <button
+            type="button"
+            onClick={applyServicePreset}
+            className="px-3 py-1.5 rounded-xl border border-border bg-card text-xs hover:bg-surface"
+          >
+            Appliquer les concentrations standards
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-3 rounded-xl border border-border bg-surface p-3">
+        <div className="text-xs font-medium text-muted mb-2">Contexte patient (sécurité)</div>
+        <div className="grid sm:grid-cols-2 gap-2">
+          <Field label="Âge" value={age} onChange={(v) => setAge(Number(v))} suffix="ans" min={0} />
+          <div className="grid grid-cols-2 gap-2">
+            <label className="text-sm text-muted">
+              Poids de référence
+              <select
+                className="mt-1 w-full rounded-md border border-border bg-surface px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                value={poidsRef}
+                onChange={(e) => setPoidsRef(e.target.value as "reel" | "ideal" | "ajuste")}
+              >
+                <option value="reel">Réel</option>
+                <option value="ideal">Idéal</option>
+                <option value="ajuste">Ajusté</option>
+              </select>
+            </label>
+            <label className="text-sm text-muted">
+              Fonction rénale
+              <select
+                className="mt-1 w-full rounded-md border border-border bg-surface px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                value={renal}
+                onChange={(e) => setRenal(e.target.value as "normal" | "renale" | "dialyse")}
+              >
+                <option value="normal">Normale</option>
+                <option value="renale">Insuffisance</option>
+                <option value="dialyse">Dialyse</option>
+              </select>
+            </label>
+          </div>
+          <label className="inline-flex items-center gap-2 text-sm text-muted">
+            <input
+              type="checkbox"
+              checked={grossesse === "oui"}
+              onChange={(e) => setGrossesse(e.target.checked ? "oui" : "non")}
+            />
+            Grossesse
+          </label>
+        </div>
+      </div>
+
       <div className="flex gap-2 mb-2 overflow-x-auto no-scrollbar">
         {(
           [
@@ -102,6 +376,7 @@ function DoseCalculator() {
             onChange={(v) => setPoids(Number(v))}
             suffix="kg"
             step="0.1"
+            min={0}
           />
           <Field
             label="Dose prescrite"
@@ -109,6 +384,7 @@ function DoseCalculator() {
             onChange={(v) => setDoseMgKg(Number(v))}
             suffix="mg/kg"
             step="0.1"
+            min={0}
           />
           <Field
             label="Concentration disponible"
@@ -116,8 +392,9 @@ function DoseCalculator() {
             onChange={(v) => setConcentration(Number(v))}
             suffix="mg/mL"
             step="0.1"
+            min={0}
           />
-          <Result>{res.text}</Result>
+          <Result tone={res.tone}>{res.text}</Result>
         </div>
       )}
 
@@ -129,6 +406,7 @@ function DoseCalculator() {
             onChange={(v) => setVoulu(Number(v))}
             suffix="mg"
             step="0.1"
+            min={0}
           />
           <Field
             label="Concentration (ce que vous avez)"
@@ -136,8 +414,9 @@ function DoseCalculator() {
             onChange={(v) => setDispo(Number(v))}
             suffix="mg/mL"
             step="0.1"
+            min={0}
           />
-          <Result>{res.text}</Result>
+          <Result tone={res.tone}>{res.text}</Result>
         </div>
       )}
 
@@ -148,6 +427,7 @@ function DoseCalculator() {
             value={contenuAmpoule}
             onChange={(v) => setContenuAmpoule(Number(v))}
             suffix="mg"
+            min={0}
           />
           <Field
             label="Volume ampoule"
@@ -155,15 +435,27 @@ function DoseCalculator() {
             onChange={(v) => setVolumeAmpoule(Number(v))}
             suffix="mL"
             step="0.1"
+            min={0}
           />
           <Field
             label="Dose souhaitée"
             value={doseSouhaitee}
             onChange={(v) => setDoseSouhaitee(Number(v))}
             suffix="mg"
+            min={0}
           />
-          <Result>{res.text}</Result>
+          <Result tone={res.tone}>{res.text}</Result>
         </div>
+      )}
+
+      {safetyAlerts.length > 0 && (
+        <ul className="mt-3 space-y-1 text-xs">
+          {safetyAlerts.map((a, i) => (
+            <li key={i} className="text-warn">
+              • {a}
+            </li>
+          ))}
+        </ul>
       )}
 
       <div className="text-xs text-muted mt-3">Double contrôle recommandé.</div>
@@ -175,6 +467,7 @@ function InfusionRate() {
   const [volume, setVolume] = useState<number>(500);
   const [heures, setHeures] = useState<number>(2);
   const [minutes, setMinutes] = useState<number>(0);
+  const [startTime, setStartTime] = useState<string>("08:00");
 
   const mlh = useMemo(() => {
     const t = Number(heures) + Number(minutes) / 60;
@@ -182,8 +475,18 @@ function InfusionRate() {
     return safeDiv(Number(volume), t);
   }, [volume, heures, minutes]);
 
+  const perfEnd = useMemo(() => {
+    const [hh, mm] = startTime.split(":").map((x) => Number(x));
+    if (!Number.isFinite(hh) || !Number.isFinite(mm)) return "—";
+    const d = new Date();
+    d.setHours(hh, mm, 0, 0);
+    const totalMin = Math.max(0, Number(heures) * 60 + Number(minutes));
+    d.setMinutes(d.getMinutes() + totalMin);
+    return d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+  }, [startTime, heures, minutes]);
+
   return (
-    <Card title="Débit d'infusion" subtitle="Calcul du mL/h">
+    <Card title="Débit d'infusion" subtitle="Calcul du mL/h + heure de fin">
       <Field
         label="Volume à perfuser"
         value={volume}
@@ -205,6 +508,16 @@ function InfusionRate() {
         />
       </div>
       <Result>{`${round(mlh)} mL/h`}</Result>
+      <label className="block mt-3">
+        <div className="text-sm text-muted mb-1">Heure de début perfusion</div>
+        <input
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+          type="time"
+          value={startTime}
+          onChange={(e) => setStartTime(e.target.value)}
+        />
+      </label>
+      <Result tone="info">Heure de fin estimée: {perfEnd}</Result>
     </Card>
   );
 }
@@ -214,7 +527,10 @@ function DripRate() {
   const [minutes, setMinutes] = useState<number>(30);
   const [df, setDf] = useState<number>(20);
 
-  const gtt = useMemo(() => safeDiv(Number(volume) * Number(df), Number(minutes)), [volume, df, minutes]);
+  const gtt = useMemo(
+    () => safeDiv(Number(volume) * Number(df), Number(minutes)),
+    [volume, df, minutes]
+  );
 
   return (
     <Card title="Gouttes par minute" subtitle="(Volume × facteur de chute) ÷ temps">
@@ -241,7 +557,231 @@ function DripRate() {
   );
 }
 
-function MiniField({ label, value, onChange, suffix }: { label: string; value: number; onChange: (v: number) => void; suffix?: string }) {
+function BiologyNorms() {
+  const items = [
+    { label: "pH artériel", range: "7.35 – 7.45" },
+    { label: "PaCO₂", range: "35 – 45 mmHg" },
+    { label: "HCO₃⁻", range: "22 – 26 mEq/L" },
+    { label: "Lactate", range: "≤ 2 mmol/L" },
+    { label: "Na⁺", range: "135 – 145 mmol/L" },
+    { label: "K⁺", range: "3.5 – 5.0 mmol/L" },
+    { label: "Créatinine", range: "≈ 45 – 105 µmol/L (adulte)" },
+    { label: "Glycémie à jeun", range: "0.70 – 1.10 g/L" },
+  ];
+
+  return (
+    <Card title="Normes biologie (repères rapides)" subtitle="Valeurs usuelles adultes — à adapter au protocole local">
+      <ul className="grid sm:grid-cols-2 gap-2 text-sm">
+        {items.map((item) => (
+          <li key={item.label} className="rounded-lg border border-border bg-surface px-3 py-2">
+            <div className="font-medium">{item.label}</div>
+            <div className="text-muted">{item.range}</div>
+          </li>
+        ))}
+      </ul>
+      <div className="text-xs text-muted mt-3">
+        Ces repères ne remplacent pas l’interprétation clinique, l’âge, le contexte et les référentiels locaux.
+      </div>
+    </Card>
+  );
+}
+
+function ServiceTools({ service }: { service: ServiceId }) {
+  if (service === "urgences") return <EmergencyTools />;
+  if (service === "usi") return <ICUTools />;
+  if (service === "grandsBrules") return <BurnTools />;
+  if (service === "pediatrie") {
+    return (
+      <Card title="Pédiatrie — rappel sécurité" subtitle="Poids et doses max">
+        <div className="text-sm text-muted">
+          Toujours vérifier le poids actualisé du jour et les doses maximales pédiatriques de la molécule.
+        </div>
+      </Card>
+    );
+  }
+  return (
+    <Card title="Polyvalent — rappel pratique" subtitle="Outils généralistes">
+      <div className="text-sm text-muted">
+        Utilisez les calculateurs de dose, débit et gouttes/min selon protocole local.
+      </div>
+    </Card>
+  );
+}
+
+function EmergencyTools() {
+  const [poids, setPoids] = useState<number>(70);
+  const [hr, setHr] = useState<number>(110);
+  const [sbp, setSbp] = useState<number>(100);
+  const bolus = round(poids * 20);
+  const shockIndex = round(safeDiv(hr, sbp));
+
+  return (
+    <Card title="Urgences — outils rapides" subtitle="Bolus et shock index">
+      <Field
+        label="Poids patient"
+        value={poids}
+        onChange={(v) => setPoids(Number(v))}
+        suffix="kg"
+        min={0}
+      />
+      <Result tone="info">Bolus cristalloïde initial ≈ {bolus} mL (20 mL/kg)</Result>
+      <div className="grid sm:grid-cols-2 gap-3 mt-3">
+        <Field
+          label="Fréquence cardiaque"
+          value={hr}
+          onChange={(v) => setHr(Number(v))}
+          suffix="/min"
+          min={0}
+        />
+        <Field
+          label="PAS"
+          value={sbp}
+          onChange={(v) => setSbp(Number(v))}
+          suffix="mmHg"
+          min={0}
+        />
+      </div>
+      <Result tone={shockIndex >= 1 ? "warn" : "success"}>Shock index = {shockIndex}</Result>
+    </Card>
+  );
+}
+
+function ICUTools() {
+  const [dose, setDose] = useState<number>(0.1);
+  const [poids, setPoids] = useState<number>(70);
+  const [mgSeringue, setMgSeringue] = useState<number>(8);
+  const [volSeringue, setVolSeringue] = useState<number>(50);
+  const concentrationMcgMl = safeDiv(mgSeringue * 1000, volSeringue);
+  const mlh = round(safeDiv(dose * poids * 60, concentrationMcgMl));
+
+  return (
+    <Card title="USI — catécholamines" subtitle="Noradrénaline µg/kg/min → mL/h">
+      <div className="grid sm:grid-cols-2 gap-3">
+        <Field
+          label="Dose cible"
+          value={dose}
+          onChange={(v) => setDose(Number(v))}
+          suffix="µg/kg/min"
+          min={0}
+          step="0.01"
+        />
+        <Field
+          label="Poids patient"
+          value={poids}
+          onChange={(v) => setPoids(Number(v))}
+          suffix="kg"
+          min={0}
+        />
+        <Field
+          label="Noradrénaline dans seringue"
+          value={mgSeringue}
+          onChange={(v) => setMgSeringue(Number(v))}
+          suffix="mg"
+          min={0}
+        />
+        <Field
+          label="Volume seringue"
+          value={volSeringue}
+          onChange={(v) => setVolSeringue(Number(v))}
+          suffix="mL"
+          min={0}
+        />
+      </div>
+      <Result tone="info">Débit pousse-seringue ≈ {mlh} mL/h</Result>
+      <div className="text-xs text-muted mt-2">
+        Toujours confirmer la concentration préparée à 2 IDE.
+      </div>
+    </Card>
+  );
+}
+
+function BurnTools() {
+  const [poids, setPoids] = useState<number>(70);
+  const [headPct, setHeadPct] = useState<number>(9);
+  const [armPct, setArmPct] = useState<number>(9);
+  const [trunkPct, setTrunkPct] = useState<number>(18);
+  const [legPct, setLegPct] = useState<number>(18);
+  const [perineumPct, setPerineumPct] = useState<number>(1);
+
+  const totalPct = Math.max(0, round(headPct + armPct + trunkPct + legPct + perineumPct));
+  const parkland24h = round(4 * poids * totalPct);
+  const first8h = round(parkland24h / 2);
+  const next16h = round(parkland24h / 2);
+
+  return (
+    <Card
+      title="Grands brûlés — surface et remplissage"
+      subtitle="Règle des 9 + formule de Parkland (adulte)"
+    >
+      <Field
+        label="Poids patient"
+        value={poids}
+        onChange={(v) => setPoids(Number(v))}
+        suffix="kg"
+        min={0}
+      />
+      <div className="grid sm:grid-cols-2 gap-3">
+        <Field
+          label="Tête/Cou brûlés"
+          value={headPct}
+          onChange={(v) => setHeadPct(Number(v))}
+          suffix="%"
+          min={0}
+        />
+        <Field
+          label="Membres sup. brûlés"
+          value={armPct}
+          onChange={(v) => setArmPct(Number(v))}
+          suffix="%"
+          min={0}
+        />
+        <Field
+          label="Tronc brûlé"
+          value={trunkPct}
+          onChange={(v) => setTrunkPct(Number(v))}
+          suffix="%"
+          min={0}
+        />
+        <Field
+          label="Membres inf. brûlés"
+          value={legPct}
+          onChange={(v) => setLegPct(Number(v))}
+          suffix="%"
+          min={0}
+        />
+        <Field
+          label="Périnée brûlé"
+          value={perineumPct}
+          onChange={(v) => setPerineumPct(Number(v))}
+          suffix="%"
+          min={0}
+        />
+      </div>
+      <Result tone={totalPct > 100 ? "danger" : "info"}>
+        Surface brûlée estimée: {totalPct}% TBSA
+      </Result>
+      <Result tone="warn">
+        Parkland 24h: {parkland24h} mL (Ringer lactate) — 8 premières heures: {first8h} mL,
+        puis 16h: {next16h} mL.
+      </Result>
+      <div className="text-xs text-muted mt-2">
+        Repère adulte: ajuster selon diurèse, lactate et protocole local.
+      </div>
+    </Card>
+  );
+}
+
+function MiniField({
+  label,
+  value,
+  onChange,
+  suffix,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  suffix?: string;
+}) {
   return (
     <label className="block">
       <div className="text-[11px] text-muted">{label}</div>
@@ -249,6 +789,7 @@ function MiniField({ label, value, onChange, suffix }: { label: string; value: n
         <input
           className="w-full rounded-lg border border-border bg-surface px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           type="number"
+          min={0}
           value={value}
           onChange={(e) => onChange(toNum(e.target.value))}
         />

--- a/src/tabs/PatientNotes.tsx
+++ b/src/tabs/PatientNotes.tsx
@@ -150,7 +150,11 @@ function NoteBlock() {
 
   const saveNotes = (next: string[]) => {
     setNotes(next);
-    localStorage.setItem('notes', JSON.stringify(next));
+    try {
+      localStorage.setItem('notes', JSON.stringify(next));
+    } catch {
+      // ignore storage errors
+    }
   };
 
   const addNote = () => {
@@ -160,6 +164,14 @@ function NoteBlock() {
     setInput('');
   };
 
+  const removeNote = (index: number) => {
+    saveNotes(notes.filter((_, i) => i !== index));
+  };
+
+  const clearNotes = () => {
+    saveNotes([]);
+  };
+
   return (
     <Card
       title="Bloc-notes rapide"
@@ -167,7 +179,8 @@ function NoteBlock() {
     >
       <textarea
         className="w-full rounded-xl border border-border bg-surface p-3 focus:outline-none focus:ring-2 focus:ring-ring"
-        placeholder="Écrire une note et appuyer sur Entrée"
+        placeholder="Écrire une note…"
+        aria-label="Saisir une note"
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={(e) => {
@@ -177,14 +190,40 @@ function NoteBlock() {
           }
         }}
       />
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={addNote}
+          className="px-3 py-2 rounded-xl border border-border bg-surface text-sm hover:bg-card"
+        >
+          Ajouter la note
+        </button>
+        {notes.length > 0 && (
+          <button
+            type="button"
+            onClick={clearNotes}
+            className="px-3 py-2 rounded-xl border border-border bg-surface text-sm hover:bg-card"
+          >
+            Effacer toutes les notes
+          </button>
+        )}
+      </div>
       {notes.length > 0 && (
         <ul className="mt-3 space-y-2">
           {notes.map((n, i) => (
             <li
               key={i}
-              className="rounded-lg border border-border bg-card/70 px-3 py-2 text-sm"
+              className="rounded-lg border border-border bg-card/70 px-3 py-2 text-sm flex items-start justify-between gap-2"
             >
-              {n}
+              <span>{n}</span>
+              <button
+                type="button"
+                onClick={() => removeNote(i)}
+                aria-label={`Supprimer la note ${i + 1}`}
+                className="text-xs rounded-md border border-border px-2 py-1 hover:bg-surface"
+              >
+                Supprimer
+              </button>
             </li>
           ))}
         </ul>

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -217,7 +217,7 @@ export function Result({
   };
   const styles = toneMap[tone] || toneMap.success;
   return (
-    <div className={`rounded-2xl border px-4 py-3 text-sm ${styles}`}>
+    <div className={`mt-3 rounded-2xl border px-4 py-4 text-base font-semibold tracking-tight tabular-nums ${styles}`}>
       {children}
     </div>
   );

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -57,7 +57,7 @@ export function Field({
       <div className="flex items-center gap-2">
         <input
           id={id}
-          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+          className="w-full rounded-md border border-border bg-surface px-3 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type={type}
           inputMode={type === 'number' ? 'decimal' : undefined}
           value={value}
@@ -99,7 +99,7 @@ export function FieldStr({
       <div className="flex items-center gap-2">
         <input
           id={id}
-          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+          className="w-full rounded-md border border-border bg-surface px-3 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
           type="text"
           inputMode="decimal"
           value={value}
@@ -138,7 +138,7 @@ export function Select({
     <label className="block mb-3">
       <div className="text-sm text-muted mb-1">{label}</div>
       <select
-        className="w-full rounded-md border border-border bg-surface px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+        className="w-full rounded-md border border-border bg-surface px-3 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
         value={String(value)}
         onChange={(e) =>
           onChange(


### PR DESCRIPTION
### Motivation
- Migrate the app from a simple tabbed starter into a focused nurse toolkit with isolated clinical calculators and quick-reference tools. 
- Improve UX with a modern header/bottom navigation, theming, iconography and clearer contextual presets for local services. 
- Surface safer defaults and runtime resilience (localStorage guards, abortable weather fetch) and provide compact isolated tool views. 

### Description
- Added `lucide-react` icons and updated `package.json`/`package-lock.json` to include the dependency. 
- Reworked app shell: replaced tab-based flow with `SectionKey` sections (`home`, `tools`, `memos`, `settings`), rebuilt `Header` and `BottomNav` for desktop/mobile and added back navigation when an isolated tool is open. 
- Implemented multiple isolated tools under `src/isolated` (`IsolatedTools.tsx`) and a `presets` provider (`src/isolated/presets.ts`) to inject service-specific defaults into Dose and Perfusion tools. 
- Large expansion and hardening of calculators in `src/tabs/Calculs.tsx` (service presets, safety alerts, many new calculation widgets and service-specific tool panels). 
- Redesigned `Home`, `Navigation`, `WeatherWidget`, `PatientNotes` and UI primitives: icons, improved layout, accessible controls, localStorage error handling, abortable weather fetch, and visual polish in `src/index.css`. 
- Minor component adjustments: `ui/UI.tsx` `Result` style updated for clearer emphasis, and many form fields/components receive additional constraints and UX improvements. 

### Testing
- Ran a full TypeScript + Vite build with `npm run build` (which runs `tsc -b && vite build`) and the build completed successfully. 
- Ran linter via `npm run lint` and no lint errors remain after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66c94f5bc83329badb1642af66c3a)